### PR TITLE
Removed Systems.Text.Encodings.Web to address CVE-2021-24112

### DIFF
--- a/SharpSCCM.csproj
+++ b/SharpSCCM.csproj
@@ -57,15 +57,13 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.ConfigurationManagement.Messaging">
       <HintPath>.\Microsoft.ConfigurationManagement.Messaging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ConfigurationManagement.Security.Cryptography">
       <HintPath>.\Microsoft.ConfigurationManagement.Security.Cryptography.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
@@ -89,12 +87,6 @@
       <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.4.7.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="3.0.41" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.4.1" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.CommandLine" version="2.0.0-beta3.22114.1" targetFramework="net472" />
@@ -9,8 +8,6 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.7.1" targetFramework="net472" />
-  <package id="System.Text.Json" version="4.7.2" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
### Description
- Removed Systems.Text.Encodings.Web to address CVE-2021-24112
- Removed other unnecessary dependencies