### PR TITLE
Added option to modify registry key permissions instead of getsystem

### DIFF
--- a/DeobfuscateNAAString/DeobfuscateNAAString.vcxproj
+++ b/DeobfuscateNAAString/DeobfuscateNAAString.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -443,22 +443,38 @@ namespace SharpSCCM
                 var getLocalNetworkAccessAccounts = new Command("naa", "Get any network access accounts for the site using WMI (requires admin privileges)");
                 localCommand.Add(getLocalNetworkAccessAccounts);
                 getLocalNetworkAccessAccounts.Add(new Argument<string>("method", "The method of obtaining the DPAPI blob: WMI or Disk"));
+                getLocalNetworkAccessAccounts.Add(new Option<bool>(new[] { "--modify-registry-permissions", "-reg" }, "Modify the permissions on the LSA secrets registry key as current admin user. Default is escalation to system via token duplication."));
                 getLocalNetworkAccessAccounts.Handler = CommandHandler.Create(
-                    (string method) =>
+                    (string method, bool reg) =>
                     {
                         if (method == "wmi")
                         {
-                            Credentials.LocalNetworkAccessAccountsWmi();
+                            if (reg)
+                            {
+                                Credentials.LocalNetworkAccessAccountsWmi(reg);
+                            }
+                            else
+                            {
+                                Credentials.LocalNetworkAccessAccountsWmi();
+                            }
                         }
                         else if (method == "disk")
                         {
-                            Credentials.LocalNetworkAccessAccountsDisk();
+                            if (reg)
+                            {
+                                Credentials.LocalNetworkAccessAccountsDisk(reg);
+                            }
+                            else
+                            {
+                                Credentials.LocalNetworkAccessAccountsDisk();
+                            }
                         }
                         else
                         {
                             Console.WriteLine("[!] A method (wmi or disk) is required!");
                         }
-                    });
+                    }
+                );
 
                 // local siteinfo
                 var localSiteInfo = new Command("siteinfo", "Get the primary Management Point and Site Code for the local host");

--- a/Program.cs
+++ b/Program.cs
@@ -444,7 +444,7 @@ namespace SharpSCCM
                 localCommand.Add(getLocalNetworkAccessAccounts);
                 getLocalNetworkAccessAccounts.Add(new Argument<string>("method", "The method of obtaining the DPAPI blob: WMI or Disk"));
                 getLocalNetworkAccessAccounts.Handler = CommandHandler.Create(
-                    (string method, string masterkey) =>
+                    (string method) =>
                     {
                         if (method == "wmi")
                         {

--- a/lib/Credentials.cs
+++ b/lib/Credentials.cs
@@ -9,7 +9,7 @@ namespace SharpSCCM
 {
     public class Credentials
     {
-        public static void LocalNetworkAccessAccountsDisk()
+        public static void LocalNetworkAccessAccountsDisk(bool reg = false)
         {
             // Thanks to @guervild on Github for contributing this code to SharpDPAPI
 
@@ -90,7 +90,7 @@ namespace SharpSCCM
             }
         }
 
-        public static void LocalNetworkAccessAccountsWmi()
+        public static void LocalNetworkAccessAccountsWmi(bool reg = false)
         {
             if (Helpers.IsHighIntegrity())
             {
@@ -110,8 +110,21 @@ namespace SharpSCCM
                         int length = (protectedUsernameBytes.Length + 16 - 1) / 16 * 16;
                         Array.Resize(ref protectedUsernameBytes, length);
 
+                        Dictionary<string, string> masterkeys = new Dictionary<string, string>;
+                        if (reg)
+                        {
+                            // Triage system master keys by modifying LSA secret registry key permissions
+                            masterkeys = Dpapi.TriageSystemMasterKeys(false, reg);
+                        }
 
-                        Dictionary<string, string> masterkeys = Dpapi.TriageSystemMasterKeys();
+                        else
+                        {
+                            // Triage system master keys by elevating to system via token duplication
+                            masterkeys = Dpapi.TriageSystemMasterKeys();
+
+                        }
+
+
 
                         Console.WriteLine("\r\n[*] SYSTEM master key cache:\r\n");
                         foreach (KeyValuePair<string, string> kvp in masterkeys)

--- a/lib/Credentials.cs
+++ b/lib/Credentials.cs
@@ -48,8 +48,19 @@ namespace SharpSCCM
 
                 if (Helpers.IsHighIntegrity())
                 {
+                    Dictionary<string, string> masterkeys;
+                    if (reg)
+                    {
+                        // Triage system master keys by modifying LSA secret registry key permissions
+                        masterkeys = Dpapi.TriageSystemMasterKeys(false, reg);
+                    }
 
-                    Dictionary<string, string> masterkeys = Dpapi.TriageSystemMasterKeys();
+                    else
+                    {
+                        // Triage system master keys by elevating to system via token duplication
+                        masterkeys = Dpapi.TriageSystemMasterKeys();
+
+                    }
 
                     Console.WriteLine("\r\n[*] SYSTEM master key cache:\r\n");
                     foreach (KeyValuePair<string, string> kvp in masterkeys)
@@ -110,7 +121,7 @@ namespace SharpSCCM
                         int length = (protectedUsernameBytes.Length + 16 - 1) / 16 * 16;
                         Array.Resize(ref protectedUsernameBytes, length);
 
-                        Dictionary<string, string> masterkeys = new Dictionary<string, string>;
+                        Dictionary<string, string> masterkeys;
                         if (reg)
                         {
                             // Triage system master keys by modifying LSA secret registry key permissions

--- a/lib/Dpapi.cs
+++ b/lib/Dpapi.cs
@@ -129,7 +129,7 @@ namespace SharpSCCM
                 // get the system and user DPAPI backup keys, showing the machine DPAPI keys
                 //  { machine , user }
 
-                var keys = LSADump.GetDPAPIKeys(true);
+                var keys = LSADump.GetDPAPIKeys(true, reg);
                 Helpers.GetSystem();
                 string systemFolder = "";
 

--- a/lib/Dpapi.cs
+++ b/lib/Dpapi.cs
@@ -118,7 +118,7 @@ namespace SharpSCCM
 
         }
 
-        public static Dictionary<string, string> TriageSystemMasterKeys(bool show = false)
+        public static Dictionary<string, string> TriageSystemMasterKeys(bool show = false, bool reg = false)
         {
             // retrieve the DPAPI_SYSTEM key and use it to decrypt any SYSTEM DPAPI masterkeys
 

--- a/lib/Dpapi.cs
+++ b/lib/Dpapi.cs
@@ -130,7 +130,7 @@ namespace SharpSCCM
                 //  { machine , user }
 
                 var keys = LSADump.GetDPAPIKeys(true, reg);
-                Helpers.GetSystem();
+               
                 string systemFolder = "";
 
                 if (!System.Environment.Is64BitProcess)

--- a/lib/LSADump.cs
+++ b/lib/LSADump.cs
@@ -104,7 +104,7 @@ namespace SharpSCCM
                 // If we're not system and we don't want to escalate, modify the LSA secrets reg key permissions instead
                 else if ((reg == true) && (alreadySystem == false))
                 {
-                    Console.WriteLine("\r\n\r\n");
+                    Console.WriteLine("\r\n");
                     foreach (string key in LsaRegKeys)
                     {
                         Console.WriteLine("[*] Modifying permissions on registry key: {0}", key);
@@ -159,7 +159,7 @@ namespace SharpSCCM
                     revertedAcl.RemoveAccessRule(newRule);
                     Registry.LocalMachine.OpenSubKey(key, RegistryKeyPermissionCheck.ReadWriteSubTree, RegistryRights.ChangePermissions).SetAccessControl(revertedAcl);
                 }
-                Console.WriteLine("\r\n\r\n");
+                Console.WriteLine("\r\n");
             }
 
             if ((!alreadySystem) && (!reg))


### PR DESCRIPTION

### Description

Added a `-reg` command to `local naa wmi` and `local naa disk` commands that will modify the ACLs on the necessary registry keys in order to read the LSA secrets. This is an alternative to getsystem, which elevates to system via token duplication.

### Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
