### PR TITLE
Fixed inline execution issue getting version via reflection (removed)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -42,7 +42,7 @@ namespace SharpSCCM
                 {
                     Console.WriteLine();
                     Console.WriteLine("  _______ _     _ _______  ______  _____  _______ _______ _______ _______");
-                    Console.WriteLine($"  |______ |_____| |_____| |_____/ |_____] |______ |       |       |  |  |    v{Assembly.GetEntryAssembly().GetName().Version}");
+                    Console.WriteLine("  |______ |_____| |_____| |_____/ |_____] |______ |       |       |  |  |");
                     Console.WriteLine("  ______| |     | |     | |    \\_ |       ______| |______ |______ |  |  |    @_Mayyhem ");
                 }
                 Console.WriteLine();


### PR DESCRIPTION
### Description

Removed version information from banner that used reflection to avoid issues executed in-process via C2

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)


### Testing

Tested using inline execute assembly from Cobalt Strike beacon to confirm fix.
