### PR TITLE
Added command to deobfuscate secret strings offline

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -52,6 +52,25 @@ namespace SharpSCCM
                 // Subcommands
                 //
 
+                // deobfuscate command
+                var deobCommand = new Command("deob", "Deobfuscate a policy secret hex string");
+                rootCommand.Add(deobCommand);
+                deobCommand.Add(new Argument<string>("secret-string", "The policy secret hex string to deobfuscate"));
+                deobCommand.Handler = CommandHandler.Create(
+                    (string secretString) =>
+                    {
+                        string deobfuscatedString;
+                        bool bDecryptSuccess = Helpers.DecryptDESSecret(secretString, out deobfuscatedString);
+                        if (bDecryptSuccess)
+                        {
+                            Console.WriteLine($"[+] Deobfuscated secret: {deobfuscatedString}\n");
+                        }
+                        else
+                        {
+                            Console.WriteLine("[!] Could not deobuscate secret!\n");
+                        }
+                    });
+
                 // exec command
                 var execCommand = new Command("exec", "Execute a command, binary, or script on a client or request NTLM authentication from a client\n" +
                     "  Permitted security roles:\n" +

--- a/Program.cs
+++ b/Program.cs
@@ -59,15 +59,21 @@ namespace SharpSCCM
                 deobCommand.Handler = CommandHandler.Create(
                     (string secretString) =>
                     {
-                        string deobfuscatedString;
-                        bool bDecryptSuccess = Helpers.DecryptDESSecret(secretString, out deobfuscatedString);
-                        if (bDecryptSuccess)
+                        try
                         {
-                            Console.WriteLine($"[+] Deobfuscated secret: {deobfuscatedString}\n");
+                            bool bDecryptSuccess = Helpers.DecryptDESSecret(secretString, out string deobfuscatedString);
+                            if (bDecryptSuccess)
+                            {
+                                Console.WriteLine($"[+] Deobfuscated secret: {deobfuscatedString}");
+                            }
+                            else
+                            {
+                                Console.WriteLine("[!] Could not deobuscate secret!");
+                            }
                         }
-                        else
+                        catch (Exception ex)
                         {
-                            Console.WriteLine("[!] Could not deobuscate secret!\n");
+                            Console.WriteLine($"[!] Could not deobuscate secret: {ex.Message}");
                         }
                     });
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SharpSCCM")]
-[assembly: AssemblyCopyright("© 2023 Chris Thompson (@_Mayyhem)")]
+[assembly: AssemblyCopyright("© 2024 Chris Thompson (@_Mayyhem)")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.8")]
-[assembly: AssemblyFileVersion("2.0.8")]
+[assembly: AssemblyVersion("2.0.9")]
+[assembly: AssemblyFileVersion("2.0.9")]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # SharpSCCM Release Notes
 
+### Version 2.0.9 (April 15, 2024)
+##### Changes
+- Added option to deobfuscate a secret string offline
+
 ### Version 2.0.8 (March 19, 2024)
 ##### Changes
 - Fix from @subat0mik for machines that require FIPS-compliant algorithms (PR #53)


### PR DESCRIPTION
### Description

Update to allow manual, offline deobfuscation of secret strings.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing
Tested on Windows.

### Bonus Points:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have incremented the build/revision number in https://github.com/Mayyhem/SharpSCCM/blob/main/Properties/AssemblyInfo.cs
- [X] I have made corresponding changes to the Wiki and RELEASE_NOTES.md
- [ ] I have added unit tests that prove my fix is effective or that my feature works
