### PR TITLE
Added get admins command to list SCCM admin users

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -27,5 +27,5 @@ using System.Runtime.InteropServices;
 //      Minor Version
 //      Revision
 //
-[assembly: AssemblyVersion("2.0.9")]
-[assembly: AssemblyFileVersion("2.0.9")]
+[assembly: AssemblyVersion("2.0.10")]
+[assembly: AssemblyFileVersion("2.0.10")]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # SharpSCCM Release Notes
 
+### Version 2.0.10 (April 15, 2024)
+##### Changes
+- Added get admins command to list SCCM admin users
+
 ### Version 2.0.9 (April 15, 2024)
 ##### Changes
 - Added option to deobfuscate a secret string offline


### PR DESCRIPTION
### Description

Added get admins command to list SCCM admin users

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing

SharpSCCM.exe get admins -sms localhost -sc cas

### Bonus Points:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have incremented the build/revision number in https://github.com/Mayyhem/SharpSCCM/blob/main/Properties/AssemblyInfo.cs
- [X] I have made corresponding changes to the Wiki and RELEASE_NOTES.md
- [ ] I have added unit tests that prove my fix is effective or that my feature works
