### PR TITLE
Update MgmtPointMessaging.cs

### DIFF
--- a/lib/MgmtPointMessaging.cs
+++ b/lib/MgmtPointMessaging.cs
@@ -572,7 +572,7 @@ namespace SharpSCCM
             string szMediaGUIDPlain = szMediaGUID.Trim(new char[] { '{', '}' });
             string szMediaGUIDCurlyBrackets = $"{{{szMediaGUIDPlain}}}";
 
-            (MessageCertificateX509 signingCertificate, MessageCertificateX509 encryptioncertificate, SmsClientId _) = GetCertsAndClientId(null, null, szEncodedSigningCert, machineGUID, null, null, null, szMediaGUIDCurlyBrackets.Substring(0, 31));
+            (MessageCertificateX509 signingCertificate, MessageCertificateX509 encryptioncertificate, SmsClientId _) = GetCertsAndClientId(null, null, szEncodedSigningCert, machineGUID, null, null, null, szMediaGUIDCurlyBrackets.Substring(1, 31));
             if (signingCertificate == null)
             {
                 return;


### PR DESCRIPTION
### Description

Fixes an issue with "get secrets" in which the provided mediaGUID displays incorrect password due to the formatting stripping off the last character and keeping the "{" in the front of the parameter. Found from copying over pxethiefy output to sharpsccm to extract secrets from policies. 

### Type of Change

- [ X ] Bug fix (non-breaking change which fixes an issue)

### Testing

This changes the substring value from 0 to 1 to prevent cutting off the password to decrypt the hex encoded certificate

download https://github.com/csandker/pxethiefy 
`python3 pxethiefy.py explore -i eth0 -a 10.0.0.5`

copy and paste output to SharpSCCM.exe

`SharpSCCM.exe get secrets -i "" -m "" -c "" -sc "" -mp ""`

The -m parameter will be truncated properly to allow for certificate decryption

### Bonus Points:

- [ X ] This changes a single value from 0 to 1