### PR TITLE
Use UTC for application assignment deadlines

### DIFF
--- a/lib/SmsProviderWmi.cs
+++ b/lib/SmsProviderWmi.cs
@@ -1093,7 +1093,7 @@ namespace SharpSCCM
                 {
                     Console.WriteLine($"[+] Creating new deployment of {applicationName} to {collection["Name"]} ({collection["CollectionID"]})");
                     string siteCode = wmiConnection.Path.ToString().Split('_').Last();
-                    string now = DateTime.Now.ToString("yyyyMMddHHmmss" + ".000000+***");
+                    string now = DateTime.UtcNow.ToString("yyyyMMddHHmmss" + ".000000+000");
                     deployment = new ManagementClass(wmiConnection, new ManagementPath("SMS_ApplicationAssignment"), null).CreateInstance();
                     deployment["ApplicationName"] = applicationName;
                     deployment["AssignmentName"] = $"{applicationName}_{collection["CollectionID"]}_Install";


### PR DESCRIPTION
  ### Description

I was playing with EXEC-1 in my lab and had some issues getting applications to fire. I found the code was using `DateTime.Now` while also setting `UseGMTTimes = true`, which would make SCCM treat the deadline as being in the future if the operator machine with a different timezone from the SCCM environment. I guess this is likely very rarely an issue, but it happened in my lab so maybe this could happen if you are ever operating across timezones or have forgot to set the system time on either side.

This changes the timestamp to `DateTime.UtcNow` with `+000` so the start time and enforcement deadline are always written as real UTC values which would be relative on the operator computer and the target client.

  ### Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

  ### Testing

  - Reproduced delayed execution before the change.
  - Ran the same `exec` flow after the change.
  - Confirmed the client treated the deployment deadline as immediate instead of delayed.

`SharpSCCM_merged.exe exec -p "cmd.exe /c whoami > C:\temp\usertest.txt" -d client --no-banner -sms mecm -sc p01`

  **Test Configuration**:
  * SCCM Site Version (result of`.\SharpSCCM.exe get class-instances SMS_Site -p Version`): Version: 5.00.9128.1000
  * SCCM Client Version (result of `.\SharpSCCM.exe local class-instances SMS_Client`): ClientVersion: 5.00.9128.1007

  ### Bonus Points:

  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have incremented the build/revision number in
  https://github.com/Mayyhem/SharpSCCM/blob/main/Properties/AssemblyInfo.cs
  - [ ] I have made corresponding changes to the Wiki and RELEASE_NOTES.md
  - [ ] I have added unit tests that prove my fix is effective or that my feature works